### PR TITLE
Hashbang clustering

### DIFF
--- a/clusterurl/clusterurl_test.go
+++ b/clusterurl/clusterurl_test.go
@@ -7,27 +7,38 @@ import (
 )
 
 func TestClusterURL(t *testing.T) {
+	testcases := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"/users/fdklsd/j4elk/23993/job/2", "/users/*/j4elk/*/job/*"},
+		{"123", "*"},
+		{"/123", "/*"},
+		{"123/", "*/"},
+		{"123/ljgdflgjf", "*/*"},
+		{"/**", "/*"},
+		{"/u/2", "/u/*"},
+		{"/v1/products/2", "/v1/products/*"},
+		{"/v1/products/22", "/v1/products/*"},
+		{"/v1/products/22j", "/v1/products/*"},
+		{"/products/1/org/3", "/products/*/org/*"},
+		{"/products//org/3", "/products//org/*"},
+		{"/v1/k6-test-runs/1", "/v1/k6-test-runs/*"},
+		{"/attach", "/attach"},
+		{"/usuarios/fdklsd/j4elk/23993/trabajo/2", "/usuarios/*/j4elk/*/trabajo/*"},
+		{"/Benutzer/fdklsd/j4elk/23993/Arbeit/2", "/Benutzer/*/j4elk/*/Arbeit/*"},
+		{"/utilisateurs/fdklsd/j4elk/23993/tache/2", "/utilisateurs/*/j4elk/*/tache/*"},
+		{"/products/", "/products/"},
+		{"/user-space/", "/user-space/"},
+		{"/user_space/", "/user_space/"},
+		{"/my-page#/route/products/1234/comments", "/my-page#/route/products/<id>/comments"},
+	}
+
 	err := InitAutoClassifier()
 	assert.NoError(t, err)
-	assert.Equal(t, "", ClusterURL(""))
-	assert.Equal(t, "/users/*/j4elk/*/job/*", ClusterURL("/users/fdklsd/j4elk/23993/job/2"))
-	assert.Equal(t, "*", ClusterURL("123"))
-	assert.Equal(t, "/*", ClusterURL("/123"))
-	assert.Equal(t, "*/", ClusterURL("123/"))
-	assert.Equal(t, "*/*", ClusterURL("123/ljgdflgjf"))
-	assert.Equal(t, "/*", ClusterURL("/**"))
-	assert.Equal(t, "/u/*", ClusterURL("/u/2"))
-	assert.Equal(t, "/v1/products/*", ClusterURL("/v1/products/2"))
-	assert.Equal(t, "/v1/products/*", ClusterURL("/v1/products/22"))
-	assert.Equal(t, "/v1/products/*", ClusterURL("/v1/products/22j"))
-	assert.Equal(t, "/products/*/org/*", ClusterURL("/products/1/org/3"))
-	assert.Equal(t, "/products//org/*", ClusterURL("/products//org/3"))
-	assert.Equal(t, "/v1/k6-test-runs/*", ClusterURL("/v1/k6-test-runs/1"))
-	assert.Equal(t, "/attach", ClusterURL("/attach"))
-	assert.Equal(t, "/usuarios/*/j4elk/*/trabajo/*", ClusterURL("/usuarios/fdklsd/j4elk/23993/trabajo/2"))
-	assert.Equal(t, "/Benutzer/*/j4elk/*/Arbeit/*", ClusterURL("/Benutzer/fdklsd/j4elk/23993/Arbeit/2"))
-	assert.Equal(t, "/utilisateurs/*/j4elk/*/tache/*", ClusterURL("/utilisateurs/fdklsd/j4elk/23993/tache/2"))
-	assert.Equal(t, "/products/", ClusterURL("/products/"))
-	assert.Equal(t, "/user-space/", ClusterURL("/user-space/"))
-	assert.Equal(t, "/user_space/", ClusterURL("/user_space/"))
+
+	for _, tc := range testcases {
+		assert.Equal(t, tc.expected, ClusterURL(tc.input))
+	}
 }


### PR DESCRIPTION
Added a new test that shows that, when clustering an URL like

```/my-page#/route/products/1234/comments```

it gets clustered to

```/*/route/products/*/comments```

instead of to

```/my-page#/route/products/*/comments```

This is common for SPA

https://github.com/grafana/clusterurl/issues/1