### PR TITLE
Fix non properly read config field

### DIFF
--- a/clusterurl/clusterurl.go
+++ b/clusterurl/clusterurl.go
@@ -139,7 +139,7 @@ func (csf *ClusterURLClassifier) isValid(c byte) bool {
 		return true
 	}
 
-	for _, ac := range DefaultConfig().AdditionalValidChars {
+	for _, ac := range csf.cfg.AdditionalValidChars {
 		if c == ac {
 			return true
 		}


### PR DESCRIPTION
  - The additional valid chars configuration was mistakenly being read from the default config instead of the actual config object.