### PR TITLE
Use lookup table for additional valid characters

### DIFF
--- a/clusterurl/clusterurl_test.go
+++ b/clusterurl/clusterurl_test.go
@@ -46,4 +46,61 @@ func TestClusterURL(t *testing.T) {
 	assert.Equal(t, "/attach", csf.ClusterURL("/attach#section-1"))
 	assert.Equal(t, "HTTP GET", csf.ClusterURL("HTTP GET"))
 	assert.Equal(t, "GET /api/cart", csf.ClusterURL("GET /api/cart?sessionId=55f4e5ea-5d6d-482a-80c4-799e3c72dfb0&currencyCode=USD"))
+	assert.Equal(t, "/getquote", csf.ClusterURL("/getquote"))
+}
+
+func BenchmarkClusterURLWithCache(b *testing.B) {
+	cfg := DefaultConfig()
+	cfg.CacheSize = 1000
+	csf, err := NewClusterURLClassifier(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Test cases representing different scenarios
+	testCases := []string{
+		"/users/fdklsd/j4elk/23993/job/2",
+		"/v1/products/22",
+		"/products/1/org/3",
+		"/attach?session_id=ddfsdsf&track_id=sjdklnfldsn",
+		"GET /user_space/",
+		"/api/hello.world",
+		"123/ljgdflgjf",
+		"",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, testCase := range testCases {
+			_ = csf.ClusterURL(testCase)
+		}
+	}
+}
+
+func BenchmarkClusterURLWithoutCache(b *testing.B) {
+	cfg := DefaultConfig()
+	cfg.CacheSize = 1
+	csf, err := NewClusterURLClassifier(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Test cases representing different scenarios
+	testCases := []string{
+		"/users/fdklsd/j4elk/23993/job/2",
+		"/v1/products/22",
+		"/products/1/org/3",
+		"/attach?session_id=ddfsdsf&track_id=sjdklnfldsn",
+		"GET /user_space/",
+		"/api/hello.world",
+		"123/ljgdflgjf",
+		"",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, testCase := range testCases {
+			_ = csf.ClusterURL(testCase)
+		}
+	}
 }

--- a/clusterurl/config.go
+++ b/clusterurl/config.go
@@ -44,5 +44,10 @@ func (c *Config) Validate() error {
 	if c.MaxSegments > 100 {
 		return fmt.Errorf("field MaxSegments cannot be greater than 100")
 	}
+
+	if len(c.AdditionalValidChars) > 100 {
+		return fmt.Errorf("field AdditionalValidChars cannot have more than 100 characters")
+	}
+
 	return nil
 }


### PR DESCRIPTION
  - For performance reasons.
  - Also adds some benchmarks and extends tests.
  - See https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/417