### PR TITLE
Add trie based collapsing of URLs

### DIFF
--- a/cmd/evaluate/main.go
+++ b/cmd/evaluate/main.go
@@ -12,10 +12,12 @@ import (
 
 func main() {
 	urlsFile := flag.String("urls", "assets/urls-list.txt", "Path to URLs file")
-	maxCard := flag.Int("max-card", 50, "Default max cardinality")
-	depth0Card := flag.Int("depth0-card", 0, "Cardinality override for depth 0 (0 = use default)")
-	depth1Card := flag.Int("depth1-card", 0, "Cardinality override for depth 1 (0 = use default)")
-	depth2Card := flag.Int("depth2-card", 0, "Cardinality override for depth 2 (0 = use default)")
+	softCard := flag.Int("soft", 10, "Soft max cardinality (preserve first N, then wildcard)")
+	hardCard := flag.Int("hard", 100, "Hard max cardinality (collapse all after N)")
+	depth0Soft := flag.Int("depth0-soft", 0, "Soft cardinality override for depth 0 (0 = use default, -1 = no limit)")
+	depth1Soft := flag.Int("depth1-soft", 0, "Soft cardinality override for depth 1 (0 = use default, -1 = no limit)")
+	depth0Hard := flag.Int("depth0-hard", 0, "Hard cardinality override for depth 0 (0 = use default, -1 = no limit)")
+	depth1Hard := flag.Int("depth1-hard", 0, "Hard cardinality override for depth 1 (0 = use default, -1 = no limit)")
 	topN := flag.Int("top", 20, "Number of top clusters to show")
 	flag.Parse()
 
@@ -25,23 +27,30 @@ func main() {
 		os.Exit(1)
 	}
 
-	depthCards := make(map[int]int)
-	if *depth0Card != 0 {
-		depthCards[0] = *depth0Card
+	depthSoftCards := make(map[int]int)
+	if *depth0Soft != 0 {
+		depthSoftCards[0] = *depth0Soft
 	}
-	if *depth1Card != 0 {
-		depthCards[1] = *depth1Card
+	if *depth1Soft != 0 {
+		depthSoftCards[1] = *depth1Soft
 	}
-	if *depth2Card != 0 {
-		depthCards[2] = *depth2Card
+
+	depthHardCards := make(map[int]int)
+	if *depth0Hard != 0 {
+		depthHardCards[0] = *depth0Hard
+	}
+	if *depth1Hard != 0 {
+		depthHardCards[1] = *depth1Hard
 	}
 
 	cfg := &trie.TrieConfig{
-		DefaultMaxCardinality: *maxCard,
-		DepthCardinalities:    depthCards,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
+		SoftMaxCardinality:     *softCard,
+		HardMaxCardinality:     *hardCard,
+		DepthSoftCardinalities: depthSoftCards,
+		DepthHardCardinalities: depthHardCards,
+		ReplaceWith:            "*",
+		Separator:              "/",
+		MaxDepth:               20,
 	}
 
 	t, err := trie.NewPathTrie(cfg)
@@ -50,14 +59,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// prime the trie.
+	// Prime the trie
 	for _, url := range urls {
 		t.Insert(url)
 	}
 
 	clustered := make(map[string]int)
 	for _, url := range urls {
-		result := t.Insert(url)
+		result := t.Lookup(url)
 		clustered[result]++
 	}
 

--- a/cmd/evaluate/main.go
+++ b/cmd/evaluate/main.go
@@ -14,6 +14,7 @@ func main() {
 	urlsFile := flag.String("urls", "assets/urls-list.txt", "Path to URLs file")
 	softCard := flag.Int("soft", 10, "Soft max cardinality (preserve first N, then wildcard)")
 	hardCard := flag.Int("hard", 100, "Hard max cardinality (collapse all after N)")
+	maxPatterns := flag.Int("max-patterns", 1000, "Global max patterns (0 = no limit)")
 	depth0Soft := flag.Int("depth0-soft", 0, "Soft cardinality override for depth 0 (0 = use default, -1 = no limit)")
 	depth1Soft := flag.Int("depth1-soft", 0, "Soft cardinality override for depth 1 (0 = use default, -1 = no limit)")
 	depth0Hard := flag.Int("depth0-hard", 0, "Hard cardinality override for depth 0 (0 = use default, -1 = no limit)")
@@ -46,6 +47,7 @@ func main() {
 	cfg := &trie.TrieConfig{
 		SoftMaxCardinality:     *softCard,
 		HardMaxCardinality:     *hardCard,
+		MaxPatterns:            *maxPatterns,
 		DepthSoftCardinalities: depthSoftCards,
 		DepthHardCardinalities: depthHardCards,
 		ReplaceWith:            "*",

--- a/cmd/evaluate/main.go
+++ b/cmd/evaluate/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/grafana/clusterurl/pkg/trie"
+)
+
+func main() {
+	urlsFile := flag.String("urls", "assets/urls-list.txt", "Path to URLs file")
+	maxCard := flag.Int("max-card", 50, "Default max cardinality")
+	depth0Card := flag.Int("depth0-card", 0, "Cardinality override for depth 0 (0 = use default)")
+	depth1Card := flag.Int("depth1-card", 0, "Cardinality override for depth 1 (0 = use default)")
+	depth2Card := flag.Int("depth2-card", 0, "Cardinality override for depth 2 (0 = use default)")
+	topN := flag.Int("top", 20, "Number of top clusters to show")
+	flag.Parse()
+
+	urls, err := loadURLs(*urlsFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading URLs: %v\n", err)
+		os.Exit(1)
+	}
+
+	depthCards := make(map[int]int)
+	if *depth0Card != 0 {
+		depthCards[0] = *depth0Card
+	}
+	if *depth1Card != 0 {
+		depthCards[1] = *depth1Card
+	}
+	if *depth2Card != 0 {
+		depthCards[2] = *depth2Card
+	}
+
+	cfg := &trie.TrieConfig{
+		DefaultMaxCardinality: *maxCard,
+		DepthCardinalities:    depthCards,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	}
+
+	t, err := trie.NewPathTrie(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating trie: %v\n", err)
+		os.Exit(1)
+	}
+
+	// prime the trie.
+	for _, url := range urls {
+		t.Insert(url)
+	}
+
+	clustered := make(map[string]int)
+	for _, url := range urls {
+		result := t.Insert(url)
+		clustered[result]++
+	}
+
+	fmt.Println("URLs after collapsing:", len(clustered))
+
+	printTopClusters(clustered, *topN)
+}
+
+func loadURLs(filepath string) ([]string, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var urls []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			urls = append(urls, line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return urls, nil
+}
+
+func printTopClusters(clustered map[string]int, n int) {
+	type kv struct {
+		Key   string
+		Value int
+	}
+
+	var sorted []kv
+	for k, v := range clustered {
+		sorted = append(sorted, kv{k, v})
+	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Value > sorted[j].Value
+	})
+
+	for i := 0; i < n && i < len(sorted); i++ {
+		fmt.Printf("%5d  %s\n", sorted[i].Value, sorted[i].Key)
+	}
+}

--- a/cmd/evaluate/main.go
+++ b/cmd/evaluate/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"time"
 
 	"github.com/grafana/clusterurl/pkg/trie"
 )
@@ -19,6 +20,8 @@ func main() {
 	depth1Soft := flag.Int("depth1-soft", 0, "Soft cardinality override for depth 1 (0 = use default, -1 = no limit)")
 	depth0Hard := flag.Int("depth0-hard", 0, "Hard cardinality override for depth 0 (0 = use default, -1 = no limit)")
 	depth1Hard := flag.Int("depth1-hard", 0, "Hard cardinality override for depth 1 (0 = use default, -1 = no limit)")
+	patternTTL := flag.Duration("pattern-ttl", 0, "Pattern TTL (e.g., 1h, 30m). 0 = no expiration")
+	pruneInterval := flag.Duration("prune-interval", time.Minute, "How often to check for stale patterns")
 	topN := flag.Int("top", 20, "Number of top clusters to show")
 	flag.Parse()
 
@@ -53,6 +56,8 @@ func main() {
 		ReplaceWith:            "*",
 		Separator:              "/",
 		MaxDepth:               20,
+		PatternTTL:             *patternTTL,
+		PruneInterval:          *pruneInterval,
 	}
 
 	t, err := trie.NewPathTrie(cfg)
@@ -60,6 +65,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error creating trie: %v\n", err)
 		os.Exit(1)
 	}
+	defer t.Stop() // stop background pruner if running
 
 	// Prime the trie
 	for _, url := range urls {

--- a/pkg/trie/config.go
+++ b/pkg/trie/config.go
@@ -1,6 +1,9 @@
 package trie
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // TrieConfig configures the behavior of a PathTrie.
 type TrieConfig struct {
@@ -45,6 +48,16 @@ type TrieConfig struct {
 	// Segments beyond this depth are still processed but appended to the result.
 	// Default: 20
 	MaxDepth int `json:"max_depth"`
+
+	// PatternTTL is the time after which unused patterns are eligible for pruning.
+	// Patterns not accessed (via Insert) within this duration will be removed.
+	// Default: 10 minutes (0 = no expiration)
+	PatternTTL time.Duration `json:"pattern_ttl"`
+
+	// PruneInterval is how often the background pruning goroutine runs.
+	// Only used if PatternTTL > 0.
+	// Default: 60 seconds (0 = no background pruning)
+	PruneInterval time.Duration `json:"prune_interval"`
 }
 
 // DefaultTrieConfig returns a sensible default configuration.
@@ -58,6 +71,8 @@ func DefaultTrieConfig() *TrieConfig {
 		ReplaceWith:            "*",
 		Separator:              "/",
 		MaxDepth:               20,
+		PatternTTL:             10 * time.Minute,
+		PruneInterval:          60 * time.Second,
 	}
 }
 
@@ -103,6 +118,15 @@ func (c *TrieConfig) Validate() error {
 		if card == 0 || card < -1 {
 			return fmt.Errorf("DepthHardCardinalities: cardinality for depth %d must be positive or -1 (no limit), got %d", depth, card)
 		}
+	}
+	if c.PatternTTL < 0 {
+		return fmt.Errorf("PatternTTL cannot be negative, got %v", c.PatternTTL)
+	}
+	if c.PruneInterval < 0 {
+		return fmt.Errorf("PruneInterval cannot be negative, got %v", c.PruneInterval)
+	}
+	if c.PruneInterval > 0 && c.PatternTTL == 0 {
+		return fmt.Errorf("PruneInterval requires PatternTTL to be set")
 	}
 	return nil
 }

--- a/pkg/trie/config.go
+++ b/pkg/trie/config.go
@@ -119,6 +119,26 @@ func (c *TrieConfig) Validate() error {
 			return fmt.Errorf("DepthHardCardinalities: cardinality for depth %d must be positive or -1 (no limit), got %d", depth, card)
 		}
 	}
+	// Validate that soft <= hard at each depth with overrides
+	for depth, softCard := range c.DepthSoftCardinalities {
+		if softCard == -1 {
+			continue // no soft limit is always valid
+		}
+		// Get the effective hard cardinality for this depth
+		hardCard := c.HardMaxCardinality
+		if c.DepthHardCardinalities != nil {
+			if h, ok := c.DepthHardCardinalities[depth]; ok {
+				if h == -1 {
+					continue // no hard limit is always valid
+				}
+				hardCard = h
+			}
+		}
+		if hardCard < softCard {
+			return fmt.Errorf("at depth %d: HardMaxCardinality (%d) must be >= SoftMaxCardinality (%d)",
+				depth, hardCard, softCard)
+		}
+	}
 	if c.PatternTTL < 0 {
 		return fmt.Errorf("PatternTTL cannot be negative, got %v", c.PatternTTL)
 	}

--- a/pkg/trie/config.go
+++ b/pkg/trie/config.go
@@ -16,6 +16,11 @@ type TrieConfig struct {
 	// Default: 100
 	HardMaxCardinality int `json:"hard_max_cardinality"`
 
+	// MaxPatterns is the global maximum number of unique patterns allowed.
+	// When exceeded, the deepest soft-collapsed nodes are hard-collapsed first.
+	// Default: 1000 (0 = no limit)
+	MaxPatterns int `json:"max_patterns"`
+
 	// DepthSoftCardinalities allows per-depth soft cardinality overrides.
 	// Key is the depth (0-indexed), value is the soft max cardinality.
 	// Use -1 for no limit at a specific depth.
@@ -47,6 +52,7 @@ func DefaultTrieConfig() *TrieConfig {
 	return &TrieConfig{
 		SoftMaxCardinality:     10,
 		HardMaxCardinality:     100,
+		MaxPatterns:            1000,
 		DepthSoftCardinalities: nil,
 		DepthHardCardinalities: nil,
 		ReplaceWith:            "*",
@@ -66,6 +72,9 @@ func (c *TrieConfig) Validate() error {
 	if c.HardMaxCardinality < c.SoftMaxCardinality {
 		return fmt.Errorf("HardMaxCardinality (%d) must be >= SoftMaxCardinality (%d)",
 			c.HardMaxCardinality, c.SoftMaxCardinality)
+	}
+	if c.MaxPatterns < 0 {
+		return fmt.Errorf("MaxPatterns must be >= 0, got %d", c.MaxPatterns)
 	}
 	if c.ReplaceWith == "" {
 		return fmt.Errorf("ReplaceWith cannot be empty")

--- a/pkg/trie/config.go
+++ b/pkg/trie/config.go
@@ -1,0 +1,70 @@
+package trie
+
+import "fmt"
+
+// TrieConfig configures the behavior of a PathTrie.
+type TrieConfig struct {
+	// DefaultMaxCardinality is the default threshold for all depths.
+	// When a node's children exceed this count, they are collapsed to a wildcard.
+	// Default: 100
+	DefaultMaxCardinality int `json:"default_max_cardinality"`
+
+	// DepthCardinalities allows per-depth cardinality overrides.
+	// Key is the depth (0-indexed, where 0 is the first segment after root),
+	// value is the max cardinality for that depth.
+	// Example: {0: 10, 1: 10} means depths 0 and 1 allow 10 children each.
+	// Depths not in the map use DefaultMaxCardinality.
+	DepthCardinalities map[int]int `json:"depth_cardinalities,omitempty"`
+
+	// ReplaceWith is the wildcard string used for collapsed segments.
+	// Default: "*"
+	ReplaceWith string `json:"replace_with"`
+
+	// Separator is the path segment separator.
+	// Default: "/"
+	Separator string `json:"separator"`
+
+	// MaxDepth limits the maximum depth of the trie to prevent unbounded growth.
+	// Segments beyond this depth are still processed but appended to the result.
+	// Default: 20
+	MaxDepth int `json:"max_depth"`
+}
+
+// DefaultTrieConfig returns a sensible default configuration.
+func DefaultTrieConfig() *TrieConfig {
+	return &TrieConfig{
+		DefaultMaxCardinality: 100,
+		DepthCardinalities:    nil,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	}
+}
+
+// Validate checks the configuration for errors.
+func (c *TrieConfig) Validate() error {
+	if c.DefaultMaxCardinality <= 0 {
+		return fmt.Errorf("DefaultMaxCardinality must be positive, got %d", c.DefaultMaxCardinality)
+	}
+	if c.ReplaceWith == "" {
+		return fmt.Errorf("ReplaceWith cannot be empty")
+	}
+	if c.Separator == "" {
+		return fmt.Errorf("Separator cannot be empty")
+	}
+	if c.MaxDepth <= 0 {
+		return fmt.Errorf("MaxDepth must be positive, got %d", c.MaxDepth)
+	}
+	if c.MaxDepth > 100 {
+		return fmt.Errorf("MaxDepth cannot exceed 100, got %d", c.MaxDepth)
+	}
+	for depth, card := range c.DepthCardinalities {
+		if depth < 0 {
+			return fmt.Errorf("DepthCardinalities: depth cannot be negative, got %d", depth)
+		}
+		if card == 0 || card < -1 {
+			return fmt.Errorf("DepthCardinalities: cardinality for depth %d must be positive or -1 (no limit), got %d", depth, card)
+		}
+	}
+	return nil
+}

--- a/pkg/trie/config.go
+++ b/pkg/trie/config.go
@@ -4,17 +4,29 @@ import "fmt"
 
 // TrieConfig configures the behavior of a PathTrie.
 type TrieConfig struct {
-	// DefaultMaxCardinality is the default threshold for all depths.
-	// When a node's children exceed this count, they are collapsed to a wildcard.
-	// Default: 100
-	DefaultMaxCardinality int `json:"default_max_cardinality"`
+	// SoftMaxCardinality is the soft threshold for all depths.
+	// After this many unique children, NEW children are mapped to wildcard,
+	// but existing children are preserved.
+	// Default: 10
+	SoftMaxCardinality int `json:"soft_max_cardinality"`
 
-	// DepthCardinalities allows per-depth cardinality overrides.
-	// Key is the depth (0-indexed, where 0 is the first segment after root),
-	// value is the max cardinality for that depth.
-	// Example: {0: 10, 1: 10} means depths 0 and 1 allow 10 children each.
-	// Depths not in the map use DefaultMaxCardinality.
-	DepthCardinalities map[int]int `json:"depth_cardinalities,omitempty"`
+	// HardMaxCardinality is the hard threshold for all depths.
+	// After this many unique children have been seen, ALL children are
+	// collapsed to a single wildcard (including previously preserved ones).
+	// Default: 100
+	HardMaxCardinality int `json:"hard_max_cardinality"`
+
+	// DepthSoftCardinalities allows per-depth soft cardinality overrides.
+	// Key is the depth (0-indexed), value is the soft max cardinality.
+	// Use -1 for no limit at a specific depth.
+	// Depths not in the map use SoftMaxCardinality.
+	DepthSoftCardinalities map[int]int `json:"depth_soft_cardinalities,omitempty"`
+
+	// DepthHardCardinalities allows per-depth hard cardinality overrides.
+	// Key is the depth (0-indexed), value is the hard max cardinality.
+	// Use -1 for no limit at a specific depth.
+	// Depths not in the map use HardMaxCardinality.
+	DepthHardCardinalities map[int]int `json:"depth_hard_cardinalities,omitempty"`
 
 	// ReplaceWith is the wildcard string used for collapsed segments.
 	// Default: "*"
@@ -33,18 +45,27 @@ type TrieConfig struct {
 // DefaultTrieConfig returns a sensible default configuration.
 func DefaultTrieConfig() *TrieConfig {
 	return &TrieConfig{
-		DefaultMaxCardinality: 100,
-		DepthCardinalities:    nil,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
+		SoftMaxCardinality:     10,
+		HardMaxCardinality:     100,
+		DepthSoftCardinalities: nil,
+		DepthHardCardinalities: nil,
+		ReplaceWith:            "*",
+		Separator:              "/",
+		MaxDepth:               20,
 	}
 }
 
 // Validate checks the configuration for errors.
 func (c *TrieConfig) Validate() error {
-	if c.DefaultMaxCardinality <= 0 {
-		return fmt.Errorf("DefaultMaxCardinality must be positive, got %d", c.DefaultMaxCardinality)
+	if c.SoftMaxCardinality <= 0 {
+		return fmt.Errorf("SoftMaxCardinality must be positive, got %d", c.SoftMaxCardinality)
+	}
+	if c.HardMaxCardinality <= 0 {
+		return fmt.Errorf("HardMaxCardinality must be positive, got %d", c.HardMaxCardinality)
+	}
+	if c.HardMaxCardinality < c.SoftMaxCardinality {
+		return fmt.Errorf("HardMaxCardinality (%d) must be >= SoftMaxCardinality (%d)",
+			c.HardMaxCardinality, c.SoftMaxCardinality)
 	}
 	if c.ReplaceWith == "" {
 		return fmt.Errorf("ReplaceWith cannot be empty")
@@ -58,12 +79,20 @@ func (c *TrieConfig) Validate() error {
 	if c.MaxDepth > 100 {
 		return fmt.Errorf("MaxDepth cannot exceed 100, got %d", c.MaxDepth)
 	}
-	for depth, card := range c.DepthCardinalities {
+	for depth, card := range c.DepthSoftCardinalities {
 		if depth < 0 {
-			return fmt.Errorf("DepthCardinalities: depth cannot be negative, got %d", depth)
+			return fmt.Errorf("DepthSoftCardinalities: depth cannot be negative, got %d", depth)
 		}
 		if card == 0 || card < -1 {
-			return fmt.Errorf("DepthCardinalities: cardinality for depth %d must be positive or -1 (no limit), got %d", depth, card)
+			return fmt.Errorf("DepthSoftCardinalities: cardinality for depth %d must be positive or -1 (no limit), got %d", depth, card)
+		}
+	}
+	for depth, card := range c.DepthHardCardinalities {
+		if depth < 0 {
+			return fmt.Errorf("DepthHardCardinalities: depth cannot be negative, got %d", depth)
+		}
+		if card == 0 || card < -1 {
+			return fmt.Errorf("DepthHardCardinalities: cardinality for depth %d must be positive or -1 (no limit), got %d", depth, card)
 		}
 	}
 	return nil

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -81,14 +81,18 @@ func NewPathTrie(config *TrieConfig) (*PathTrie, error) {
 		cfg: config,
 	}
 
+	return t, nil
+}
+
+// Start starts the background routine for pruning stale paths from the trie.
+// Must call `Stop` when you want to clean up the trie to avoid goroutine leaks.
+func (t *PathTrie) Start() {
 	// Start background pruning if configured
-	if config.PruneInterval > 0 && config.PatternTTL > 0 {
+	if t.cfg.PruneInterval > 0 && t.cfg.PatternTTL > 0 {
 		t.stopPrune = make(chan struct{})
 		t.pruneWg.Add(1)
-		go t.startPruneLoop()
+		go t.startPruneLoop(t.stopPrune)
 	}
-
-	return t, nil
 }
 
 // getSoftMaxCardinality returns the soft max cardinality for a given depth.
@@ -162,6 +166,8 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 	current := t.root
 	result := make([]string, 0, len(segments))
 
+	// We start at depth=0, with current=root (depth=-1).
+	// This means current.depth is always `depth-1`.
 	for depth, segment := range segments {
 		if segment == "" {
 			result = append(result, segment)
@@ -177,7 +183,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 		// Case 1: Node is hard collapsed - everything goes to wildcard
 		if current.hardCollapsed {
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcard(current, depth)
+			current = t.getOrCreateWildcardChild(current)
 			continue
 		}
 
@@ -207,7 +213,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 
 			// Use wildcard
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcard(current, depth)
+			current = t.getOrCreateWildcardChild(current)
 			continue
 		}
 
@@ -245,7 +251,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 
 			// Soft collapse only - use wildcard for this new segment
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcard(current, depth)
+			current = t.getOrCreateWildcardChild(current)
 			continue
 		}
 
@@ -268,14 +274,14 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 	return result
 }
 
-// getOrCreateWildcard returns the wildcard child of a node, creating it if needed.
-func (t *PathTrie) getOrCreateWildcard(node *pathNode, depth int) *pathNode {
+// getOrCreateWildcardChild returns the wildcard child of a node, creating it if needed.
+func (t *PathTrie) getOrCreateWildcardChild(node *pathNode) *pathNode {
 	if node.children[t.cfg.ReplaceWith] == nil {
 		node.children[t.cfg.ReplaceWith] = &pathNode{
 			segment:    t.cfg.ReplaceWith,
 			children:   make(map[string]*pathNode),
 			isWildcard: true,
-			depth:      depth,
+			depth:      node.depth + 1,
 		}
 	}
 	return node.children[t.cfg.ReplaceWith]
@@ -291,26 +297,25 @@ func (t *PathTrie) hardCollapseNode(node *pathNode) {
 	node.softCollapsed = true
 	node.wildcardedSegments = nil // no longer needed after hard collapse
 
-	// Create or get wildcard node (children are at depth+1)
-	wildcardNode := t.getOrCreateWildcard(node, node.depth+1)
+	wildcardChild := t.getOrCreateWildcardChild(node)
 
 	// Merge all explicit children into the wildcard node
 	for segment, child := range node.children {
 		if segment == t.cfg.ReplaceWith {
 			continue // Skip the wildcard itself
 		}
-		t.mergeChildren(wildcardNode, child)
+		t.mergeChildren(wildcardChild, child)
 	}
 
 	// Replace all children with just the wildcard
 	node.children = map[string]*pathNode{
-		t.cfg.ReplaceWith: wildcardNode,
+		t.cfg.ReplaceWith: wildcardChild,
 	}
 
 	// Recursively check if wildcard node needs hard collapsing
 	// Use default thresholds for merged nodes
-	if wildcardNode.uniqueChildrenSeen > t.cfg.HardMaxCardinality {
-		t.hardCollapseNode(wildcardNode)
+	if wildcardChild.uniqueChildrenSeen > t.cfg.HardMaxCardinality {
+		t.hardCollapseNode(wildcardChild)
 	}
 }
 
@@ -573,7 +578,7 @@ func (t *PathTrie) pruneNode(node *pathNode, cutoff time.Time) int {
 
 // startPruneLoop runs the background pruning loop.
 // It periodically calls PruneStale to remove patterns that haven't been seen recently.
-func (t *PathTrie) startPruneLoop() {
+func (t *PathTrie) startPruneLoop(stopChan chan struct{}) {
 	defer t.pruneWg.Done()
 
 	ticker := time.NewTicker(t.cfg.PruneInterval)
@@ -583,7 +588,7 @@ func (t *PathTrie) startPruneLoop() {
 		select {
 		case <-ticker.C:
 			t.PruneStale(time.Now().Add(-t.cfg.PatternTTL))
-		case <-t.stopPrune:
+		case <-stopChan:
 			return
 		}
 	}
@@ -593,9 +598,17 @@ func (t *PathTrie) startPruneLoop() {
 // Call this when done with the trie to clean up resources.
 // It is safe to call Stop multiple times or on a trie without background pruning.
 func (t *PathTrie) Stop() {
-	if t.stopPrune != nil {
-		close(t.stopPrune)
+	// If we do a simple defer t.mu.Unlock(), then the background routine in prune
+	// can trigger a PruneStale() that also tries to acquire the lock. That routine
+	// will be stuck, and this current routine will be stuck on `t.pruneWg.Wait()`
+	// as well.
+	t.mu.Lock()
+	stopChan := t.stopPrune
+	t.stopPrune = nil // prevent double close
+	t.mu.Unlock()     // Release lock BEFORE waiting.
+
+	if stopChan != nil {
+		close(stopChan)
 		t.pruneWg.Wait()
-		t.stopPrune = nil // prevent double close
 	}
 }

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 )
 
 // pathNode represents a single segment in the URL path trie.
@@ -27,11 +28,19 @@ type pathNode struct {
 	// Used to determine when to trigger hard collapse.
 	uniqueChildrenSeen int
 
+	// wildcardedSegments tracks segments that were routed to wildcard after soft collapse.
+	// This prevents counting the same segment multiple times toward hard collapse.
+	wildcardedSegments map[string]struct{}
+
 	// isWildcard indicates if this node represents a collapsed wildcard
 	isWildcard bool
 
 	// depth is the depth of this node in the trie (root children = 0)
 	depth int
+
+	// lastSeen is when this node was last accessed via Insert.
+	// Used for TTL-based pruning.
+	lastSeen time.Time
 }
 
 // PathTrie is a thread-safe trie for clustering URL paths.
@@ -44,10 +53,16 @@ type PathTrie struct {
 	mu           sync.RWMutex
 	cfg          *TrieConfig
 	patternCount int // current number of unique patterns (leaf paths)
+
+	// Pruning goroutine control
+	stopPrune chan struct{}  // signal to stop background pruning
+	pruneWg   sync.WaitGroup // wait for pruner goroutine to exit
 }
 
 // NewPathTrie creates a new PathTrie with the given configuration.
 // If config is nil, DefaultTrieConfig() is used.
+// If PruneInterval is configured, a background goroutine is started to prune stale patterns.
+// Call Stop() when done with the trie to stop the background goroutine.
 func NewPathTrie(config *TrieConfig) (*PathTrie, error) {
 	if config == nil {
 		config = DefaultTrieConfig()
@@ -57,14 +72,23 @@ func NewPathTrie(config *TrieConfig) (*PathTrie, error) {
 		return nil, err
 	}
 
-	return &PathTrie{
+	t := &PathTrie{
 		root: &pathNode{
 			segment:  "",
 			children: make(map[string]*pathNode),
 			depth:    -1, // root is at depth -1, so children are at depth 0
 		},
 		cfg: config,
-	}, nil
+	}
+
+	// Start background pruning if configured
+	if config.PruneInterval > 0 && config.PatternTTL > 0 {
+		t.stopPrune = make(chan struct{})
+		t.pruneWg.Add(1)
+		go t.startPruneLoop()
+	}
+
+	return t, nil
 }
 
 // getSoftMaxCardinality returns the soft max cardinality for a given depth.
@@ -100,14 +124,6 @@ func (t *PathTrie) parsePath(path string) []string {
 		path = path[:idx]
 	}
 
-	// Handle HTTP method prefix (e.g., "GET /path")
-	if idx := strings.Index(path, " "); idx > 0 {
-		op := path[:idx]
-		if isHTTPMethod(op) && idx < len(path) {
-			path = path[idx+1:]
-		}
-	}
-
 	// Trim leading/trailing separators and split
 	path = strings.Trim(path, t.cfg.Separator)
 	if path == "" {
@@ -115,15 +131,6 @@ func (t *PathTrie) parsePath(path string) []string {
 	}
 
 	return strings.Split(path, t.cfg.Separator)
-}
-
-// isHTTPMethod checks if the string is an HTTP method.
-func isHTTPMethod(op string) bool {
-	switch op {
-	case "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD":
-		return true
-	}
-	return false
 }
 
 // Insert adds a path to the trie and returns the normalized/clustered path.
@@ -183,16 +190,19 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 				continue
 			}
 
-			// New segment after soft collapse - count it and use wildcard
-			current.uniqueChildrenSeen++
+			// Check if this is a new unique segment we haven't seen before
+			if _, seen := current.wildcardedSegments[segment]; !seen {
+				current.wildcardedSegments[segment] = struct{}{}
+				current.uniqueChildrenSeen++
 
-			// Check if we've hit the hard threshold
-			hardMax := t.getHardMaxCardinality(depth)
-			if current.uniqueChildrenSeen > hardMax {
-				t.hardCollapseNode(current)
-				result = append(result, t.cfg.ReplaceWith)
-				current = current.children[t.cfg.ReplaceWith]
-				continue
+				// Check if we've hit the hard threshold
+				hardMax := t.getHardMaxCardinality(depth)
+				if current.uniqueChildrenSeen > hardMax {
+					t.hardCollapseNode(current)
+					result = append(result, t.cfg.ReplaceWith)
+					current = current.children[t.cfg.ReplaceWith]
+					continue
+				}
 			}
 
 			// Use wildcard
@@ -217,6 +227,12 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 		if current.uniqueChildrenSeen > softMax {
 			// Hit soft threshold - mark as soft collapsed
 			current.softCollapsed = true
+
+			// Track the triggering segment so it won't be counted again
+			if current.wildcardedSegments == nil {
+				current.wildcardedSegments = make(map[string]struct{})
+			}
+			current.wildcardedSegments[segment] = struct{}{}
 
 			// Check if we also hit hard threshold
 			hardMax := t.getHardMaxCardinality(depth)
@@ -244,6 +260,11 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 		current = child
 	}
 
+	// Update lastSeen on the final node for TTL tracking
+	if current != t.root {
+		current.lastSeen = time.Now()
+	}
+
 	return result
 }
 
@@ -268,6 +289,7 @@ func (t *PathTrie) hardCollapseNode(node *pathNode) {
 
 	node.hardCollapsed = true
 	node.softCollapsed = true
+	node.wildcardedSegments = nil // no longer needed after hard collapse
 
 	// Create or get wildcard node (children are at depth+1)
 	wildcardNode := t.getOrCreateWildcard(node, node.depth+1)
@@ -294,6 +316,7 @@ func (t *PathTrie) hardCollapseNode(node *pathNode) {
 
 // mergeChildren merges children from source into target.
 // This is called during hard collapse to combine all child paths.
+// TODO(goutham): Verify this works well.
 func (t *PathTrie) mergeChildren(target, source *pathNode) {
 	for segment, child := range source.children {
 		if existing, exists := target.children[segment]; exists {
@@ -426,11 +449,13 @@ func (t *PathTrie) PatternCount() int {
 
 // countPatterns counts all leaf nodes (nodes with no children) in the subtree.
 // This represents the number of unique patterns.
+// Root is not counted as a pattern.
 func (t *PathTrie) countPatterns(node *pathNode) int {
 	if node == nil {
 		return 0
 	}
-	if len(node.children) == 0 {
+	// Don't count root as a pattern
+	if len(node.children) == 0 && node != t.root {
 		return 1
 	}
 	count := 0
@@ -487,5 +512,90 @@ func (t *PathTrie) enforcePatternLimit() {
 		// Hard collapse the deepest candidate
 		t.hardCollapseNode(candidates[0])
 		t.updatePatternCount()
+	}
+}
+
+// PruneStale removes leaf patterns that haven't been seen since the given cutoff time.
+// Returns the number of patterns pruned. Thread-safe.
+func (t *PathTrie) PruneStale(cutoff time.Time) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.cfg.PatternTTL == 0 {
+		return 0 // TTL disabled
+	}
+
+	pruned := t.pruneNode(t.root, cutoff)
+	if pruned > 0 {
+		t.updatePatternCount()
+	}
+	return pruned
+}
+
+// pruneNode recursively prunes stale nodes from the given node's subtree.
+// Returns the number of leaf patterns pruned.
+// Must be called with lock held.
+func (t *PathTrie) pruneNode(node *pathNode, cutoff time.Time) int {
+	if node == nil {
+		return 0
+	}
+
+	pruned := 0
+	toDelete := make([]string, 0)
+
+	for segment, child := range node.children {
+		// First, recursively prune children
+		pruned += t.pruneNode(child, cutoff)
+
+		// Check if this child should be pruned:
+		// 1. It's a leaf (no children) AND
+		// 2. Either it has a stale lastSeen, OR it has no lastSeen (empty intermediate node)
+		if len(child.children) == 0 {
+			// If lastSeen is zero, this is an intermediate node that became empty after pruning
+			// If lastSeen is before cutoff, this is a stale leaf
+			if child.lastSeen.IsZero() || child.lastSeen.Before(cutoff) {
+				toDelete = append(toDelete, segment)
+				// Only count as pruned if it was a real leaf (had lastSeen set)
+				if !child.lastSeen.IsZero() {
+					pruned++
+				}
+			}
+		}
+	}
+
+	// Delete stale/empty children
+	for _, segment := range toDelete {
+		delete(node.children, segment)
+	}
+
+	return pruned
+}
+
+// startPruneLoop runs the background pruning loop.
+// It periodically calls PruneStale to remove patterns that haven't been seen recently.
+func (t *PathTrie) startPruneLoop() {
+	defer t.pruneWg.Done()
+
+	ticker := time.NewTicker(t.cfg.PruneInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			t.PruneStale(time.Now().Add(-t.cfg.PatternTTL))
+		case <-t.stopPrune:
+			return
+		}
+	}
+}
+
+// Stop stops the background pruning goroutine if it was started.
+// Call this when done with the trie to clean up resources.
+// It is safe to call Stop multiple times or on a trie without background pruning.
+func (t *PathTrie) Stop() {
+	if t.stopPrune != nil {
+		close(t.stopPrune)
+		t.pruneWg.Wait()
+		t.stopPrune = nil // prevent double close
 	}
 }

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -2,6 +2,7 @@ package trie
 
 import (
 	"math"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -28,16 +29,21 @@ type pathNode struct {
 
 	// isWildcard indicates if this node represents a collapsed wildcard
 	isWildcard bool
+
+	// depth is the depth of this node in the trie (root children = 0)
+	depth int
 }
 
 // PathTrie is a thread-safe trie for clustering URL paths.
 // It uses a two-threshold system:
 // - Soft threshold: After N unique children, new children go to wildcard but existing are preserved
 // - Hard threshold: After M unique children, all children collapse to a single wildcard
+// Additionally, a global MaxPatterns limit can trigger hard collapse of deepest soft-collapsed nodes.
 type PathTrie struct {
-	root *pathNode
-	mu   sync.RWMutex
-	cfg  *TrieConfig
+	root         *pathNode
+	mu           sync.RWMutex
+	cfg          *TrieConfig
+	patternCount int // current number of unique patterns (leaf paths)
 }
 
 // NewPathTrie creates a new PathTrie with the given configuration.
@@ -55,6 +61,7 @@ func NewPathTrie(config *TrieConfig) (*PathTrie, error) {
 		root: &pathNode{
 			segment:  "",
 			children: make(map[string]*pathNode),
+			depth:    -1, // root is at depth -1, so children are at depth 0
 		},
 		cfg: config,
 	}, nil
@@ -123,6 +130,7 @@ func isHTTPMethod(op string) bool {
 // Uses two-threshold collapsing:
 // - After soft threshold: new children go to wildcard, existing preserved
 // - After hard threshold: all children collapse to wildcard
+// Additionally, if MaxPatterns is exceeded, deepest soft-collapsed nodes are hard-collapsed.
 // Thread-safe.
 func (t *PathTrie) Insert(path string) string {
 	t.mu.Lock()
@@ -134,6 +142,11 @@ func (t *PathTrie) Insert(path string) string {
 	}
 
 	result := t.insertSegments(segments)
+
+	// Update pattern count and enforce limit
+	t.updatePatternCount()
+	t.enforcePatternLimit()
+
 	return t.cfg.Separator + strings.Join(result, t.cfg.Separator)
 }
 
@@ -157,7 +170,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 		// Case 1: Node is hard collapsed - everything goes to wildcard
 		if current.hardCollapsed {
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcard(current)
+			current = t.getOrCreateWildcard(current, depth)
 			continue
 		}
 
@@ -184,7 +197,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 
 			// Use wildcard
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcard(current)
+			current = t.getOrCreateWildcard(current, depth)
 			continue
 		}
 
@@ -216,7 +229,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 
 			// Soft collapse only - use wildcard for this new segment
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcard(current)
+			current = t.getOrCreateWildcard(current, depth)
 			continue
 		}
 
@@ -224,6 +237,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 		child = &pathNode{
 			segment:  segment,
 			children: make(map[string]*pathNode),
+			depth:    depth,
 		}
 		current.children[segment] = child
 		result = append(result, segment)
@@ -234,12 +248,13 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 }
 
 // getOrCreateWildcard returns the wildcard child of a node, creating it if needed.
-func (t *PathTrie) getOrCreateWildcard(node *pathNode) *pathNode {
+func (t *PathTrie) getOrCreateWildcard(node *pathNode, depth int) *pathNode {
 	if node.children[t.cfg.ReplaceWith] == nil {
 		node.children[t.cfg.ReplaceWith] = &pathNode{
 			segment:    t.cfg.ReplaceWith,
 			children:   make(map[string]*pathNode),
 			isWildcard: true,
+			depth:      depth,
 		}
 	}
 	return node.children[t.cfg.ReplaceWith]
@@ -254,8 +269,8 @@ func (t *PathTrie) hardCollapseNode(node *pathNode) {
 	node.hardCollapsed = true
 	node.softCollapsed = true
 
-	// Create or get wildcard node
-	wildcardNode := t.getOrCreateWildcard(node)
+	// Create or get wildcard node (children are at depth+1)
+	wildcardNode := t.getOrCreateWildcard(node, node.depth+1)
 
 	// Merge all explicit children into the wildcard node
 	for segment, child := range node.children {
@@ -374,7 +389,9 @@ func (t *PathTrie) Reset() {
 	t.root = &pathNode{
 		segment:  "",
 		children: make(map[string]*pathNode),
+		depth:    -1,
 	}
+	t.patternCount = 0
 }
 
 // NodeCount returns the approximate number of nodes in the trie.
@@ -396,4 +413,79 @@ func (t *PathTrie) countNodes(node *pathNode) int {
 		count += t.countNodes(child)
 	}
 	return count
+}
+
+// PatternCount returns the current number of unique patterns in the trie.
+// A pattern is a unique path from root to a leaf node.
+// Thread-safe.
+func (t *PathTrie) PatternCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.patternCount
+}
+
+// countPatterns counts all leaf nodes (nodes with no children) in the subtree.
+// This represents the number of unique patterns.
+func (t *PathTrie) countPatterns(node *pathNode) int {
+	if node == nil {
+		return 0
+	}
+	if len(node.children) == 0 {
+		return 1
+	}
+	count := 0
+	for _, child := range node.children {
+		count += t.countPatterns(child)
+	}
+	return count
+}
+
+// updatePatternCount recalculates the pattern count by traversing the trie.
+func (t *PathTrie) updatePatternCount() {
+	t.patternCount = t.countPatterns(t.root)
+}
+
+// findCollapseCandidates returns all soft-collapsed nodes that haven't been hard-collapsed.
+// These are candidates for hard collapse when over the pattern limit.
+func (t *PathTrie) findCollapseCandidates() []*pathNode {
+	var candidates []*pathNode
+	t.collectCandidates(t.root, &candidates)
+	return candidates
+}
+
+// collectCandidates recursively collects soft-collapsed nodes.
+func (t *PathTrie) collectCandidates(node *pathNode, candidates *[]*pathNode) {
+	if node == nil {
+		return
+	}
+	if node.softCollapsed && !node.hardCollapsed {
+		*candidates = append(*candidates, node)
+	}
+	for _, child := range node.children {
+		t.collectCandidates(child, candidates)
+	}
+}
+
+// enforcePatternLimit checks if the pattern count exceeds MaxPatterns.
+// If so, it hard-collapses the deepest soft-collapsed nodes until under the limit.
+func (t *PathTrie) enforcePatternLimit() {
+	if t.cfg.MaxPatterns <= 0 {
+		return // no limit
+	}
+
+	for t.patternCount > t.cfg.MaxPatterns {
+		candidates := t.findCollapseCandidates()
+		if len(candidates) == 0 {
+			break // no candidates to collapse, accept over limit
+		}
+
+		// Sort by depth descending (deepest first)
+		sort.Slice(candidates, func(i, j int) bool {
+			return candidates[i].depth > candidates[j].depth
+		})
+
+		// Hard collapse the deepest candidate
+		t.hardCollapseNode(candidates[0])
+		t.updatePatternCount()
+	}
 }

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -14,18 +14,26 @@ type pathNode struct {
 	// children maps segment strings to child nodes
 	children map[string]*pathNode
 
-	// collapsed indicates if this node's children have been collapsed to a wildcard
-	collapsed bool
+	// softCollapsed indicates this node has passed the soft threshold.
+	// New children will be directed to the wildcard, but existing children are preserved.
+	softCollapsed bool
 
-	// cardinality tracks the number of distinct children observed
-	cardinality int
+	// hardCollapsed indicates this node has passed the hard threshold.
+	// All children have been merged into a single wildcard.
+	hardCollapsed bool
+
+	// uniqueChildrenSeen tracks the total number of unique children ever seen.
+	// Used to determine when to trigger hard collapse.
+	uniqueChildrenSeen int
 
 	// isWildcard indicates if this node represents a collapsed wildcard
 	isWildcard bool
 }
 
 // PathTrie is a thread-safe trie for clustering URL paths.
-// It dynamically collapses high-cardinality segments into wildcards.
+// It uses a two-threshold system:
+// - Soft threshold: After N unique children, new children go to wildcard but existing are preserved
+// - Hard threshold: After M unique children, all children collapse to a single wildcard
 type PathTrie struct {
 	root *pathNode
 	mu   sync.RWMutex
@@ -52,19 +60,30 @@ func NewPathTrie(config *TrieConfig) (*PathTrie, error) {
 	}, nil
 }
 
-// getMaxCardinality returns the max cardinality for a given depth.
-// It checks DepthCardinalities first, then falls back to DefaultMaxCardinality.
-// A value of -1 in DepthCardinalities means no limit (never collapse).
-func (t *PathTrie) getMaxCardinality(depth int) int {
-	if t.cfg.DepthCardinalities != nil {
-		if card, ok := t.cfg.DepthCardinalities[depth]; ok {
+// getSoftMaxCardinality returns the soft max cardinality for a given depth.
+func (t *PathTrie) getSoftMaxCardinality(depth int) int {
+	if t.cfg.DepthSoftCardinalities != nil {
+		if card, ok := t.cfg.DepthSoftCardinalities[depth]; ok {
 			if card == -1 {
 				return math.MaxInt
 			}
 			return card
 		}
 	}
-	return t.cfg.DefaultMaxCardinality
+	return t.cfg.SoftMaxCardinality
+}
+
+// getHardMaxCardinality returns the hard max cardinality for a given depth.
+func (t *PathTrie) getHardMaxCardinality(depth int) int {
+	if t.cfg.DepthHardCardinalities != nil {
+		if card, ok := t.cfg.DepthHardCardinalities[depth]; ok {
+			if card == -1 {
+				return math.MaxInt
+			}
+			return card
+		}
+	}
+	return t.cfg.HardMaxCardinality
 }
 
 // parsePath splits a path into segments, handling query strings and edge cases.
@@ -101,7 +120,9 @@ func isHTTPMethod(op string) bool {
 }
 
 // Insert adds a path to the trie and returns the normalized/clustered path.
-// If a segment exceeds maxCardinality, it collapses to the wildcard.
+// Uses two-threshold collapsing:
+// - After soft threshold: new children go to wildcard, existing preserved
+// - After hard threshold: all children collapse to wildcard
 // Thread-safe.
 func (t *PathTrie) Insert(path string) string {
 	t.mu.Lock()
@@ -133,53 +154,78 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 			break
 		}
 
-		// If current node is already collapsed, all children become wildcards
-		if current.collapsed {
+		// Case 1: Node is hard collapsed - everything goes to wildcard
+		if current.hardCollapsed {
 			result = append(result, t.cfg.ReplaceWith)
-			// Continue with the wildcard child
-			if current.children[t.cfg.ReplaceWith] == nil {
-				current.children[t.cfg.ReplaceWith] = &pathNode{
-					segment:    t.cfg.ReplaceWith,
-					children:   make(map[string]*pathNode),
-					isWildcard: true,
-				}
-			}
-			current = current.children[t.cfg.ReplaceWith]
+			current = t.getOrCreateWildcard(current)
 			continue
 		}
 
-		// Check if this segment already exists
-		child, exists := current.children[segment]
+		// Case 2: Node is soft collapsed - check if segment exists or use wildcard
+		if current.softCollapsed {
+			// Check if this segment is one of the preserved explicit children
+			if child, exists := current.children[segment]; exists && segment != t.cfg.ReplaceWith {
+				result = append(result, segment)
+				current = child
+				continue
+			}
 
-		if !exists {
-			maxCard := t.getMaxCardinality(depth)
+			// New segment after soft collapse - count it and use wildcard
+			current.uniqueChildrenSeen++
 
-			// New segment - check if we need to collapse
-			if current.cardinality >= maxCard {
-				// Collapse this level
-				t.collapseNode(current)
+			// Check if we've hit the hard threshold
+			hardMax := t.getHardMaxCardinality(depth)
+			if current.uniqueChildrenSeen > hardMax {
+				t.hardCollapseNode(current)
 				result = append(result, t.cfg.ReplaceWith)
 				current = current.children[t.cfg.ReplaceWith]
 				continue
 			}
 
-			// Create new child
-			child = &pathNode{
-				segment:  segment,
-				children: make(map[string]*pathNode),
-			}
-			current.children[segment] = child
-			current.cardinality++
-
-			// Check if we just hit the threshold
-			if current.cardinality > maxCard {
-				t.collapseNode(current)
-				result = append(result, t.cfg.ReplaceWith)
-				current = current.children[t.cfg.ReplaceWith]
-				continue
-			}
+			// Use wildcard
+			result = append(result, t.cfg.ReplaceWith)
+			current = t.getOrCreateWildcard(current)
+			continue
 		}
 
+		// Case 3: Normal operation - not yet soft collapsed
+		child, exists := current.children[segment]
+
+		if exists {
+			result = append(result, segment)
+			current = child
+			continue
+		}
+
+		// New segment - check soft threshold
+		current.uniqueChildrenSeen++
+		softMax := t.getSoftMaxCardinality(depth)
+
+		if current.uniqueChildrenSeen > softMax {
+			// Hit soft threshold - mark as soft collapsed
+			current.softCollapsed = true
+
+			// Check if we also hit hard threshold
+			hardMax := t.getHardMaxCardinality(depth)
+			if current.uniqueChildrenSeen > hardMax {
+				t.hardCollapseNode(current)
+				result = append(result, t.cfg.ReplaceWith)
+				current = current.children[t.cfg.ReplaceWith]
+				continue
+			}
+
+			// Soft collapse only - use wildcard for this new segment
+			result = append(result, t.cfg.ReplaceWith)
+			current = t.getOrCreateWildcard(current)
+			continue
+		}
+
+		// Under soft threshold - create new explicit child
+		child = &pathNode{
+			segment:  segment,
+			children: make(map[string]*pathNode),
+		}
+		current.children[segment] = child
 		result = append(result, segment)
 		current = child
 	}
@@ -187,26 +233,31 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 	return result
 }
 
-// collapseNode collapses a node by replacing all children with a single wildcard
-// and merging their children into the wildcard node.
-func (t *PathTrie) collapseNode(node *pathNode) {
-	if node.collapsed {
-		return
-	}
-
-	node.collapsed = true
-
-	// Create or get wildcard node
-	wildcardNode, hasWildcard := node.children[t.cfg.ReplaceWith]
-	if !hasWildcard {
-		wildcardNode = &pathNode{
+// getOrCreateWildcard returns the wildcard child of a node, creating it if needed.
+func (t *PathTrie) getOrCreateWildcard(node *pathNode) *pathNode {
+	if node.children[t.cfg.ReplaceWith] == nil {
+		node.children[t.cfg.ReplaceWith] = &pathNode{
 			segment:    t.cfg.ReplaceWith,
 			children:   make(map[string]*pathNode),
 			isWildcard: true,
 		}
 	}
+	return node.children[t.cfg.ReplaceWith]
+}
 
-	// Merge all children into the wildcard node
+// hardCollapseNode performs a hard collapse: merges all children into a single wildcard.
+func (t *PathTrie) hardCollapseNode(node *pathNode) {
+	if node.hardCollapsed {
+		return
+	}
+
+	node.hardCollapsed = true
+	node.softCollapsed = true
+
+	// Create or get wildcard node
+	wildcardNode := t.getOrCreateWildcard(node)
+
+	// Merge all explicit children into the wildcard node
 	for segment, child := range node.children {
 		if segment == t.cfg.ReplaceWith {
 			continue // Skip the wildcard itself
@@ -218,26 +269,36 @@ func (t *PathTrie) collapseNode(node *pathNode) {
 	node.children = map[string]*pathNode{
 		t.cfg.ReplaceWith: wildcardNode,
 	}
-	node.cardinality = 1
 
-	// Recursively check if wildcard node needs collapsing
-	// Use depth 0 for the wildcard node's children since we don't track depth in nodes
-	if wildcardNode.cardinality > t.cfg.DefaultMaxCardinality {
-		t.collapseNode(wildcardNode)
+	// Recursively check if wildcard node needs hard collapsing
+	// Use default thresholds for merged nodes
+	if wildcardNode.uniqueChildrenSeen > t.cfg.HardMaxCardinality {
+		t.hardCollapseNode(wildcardNode)
 	}
 }
 
 // mergeChildren merges children from source into target.
-// This is called during collapse to combine all child paths.
+// This is called during hard collapse to combine all child paths.
 func (t *PathTrie) mergeChildren(target, source *pathNode) {
 	for segment, child := range source.children {
 		if existing, exists := target.children[segment]; exists {
 			// Child already exists, recursively merge their children
 			t.mergeChildren(existing, child)
+			// Inherit collapse state
+			if child.softCollapsed {
+				existing.softCollapsed = true
+			}
+			if child.hardCollapsed {
+				existing.hardCollapsed = true
+			}
+			// Take max of uniqueChildrenSeen
+			if child.uniqueChildrenSeen > existing.uniqueChildrenSeen {
+				existing.uniqueChildrenSeen = child.uniqueChildrenSeen
+			}
 		} else {
 			// New child, add it
 			target.children[segment] = child
-			target.cardinality++
+			target.uniqueChildrenSeen++
 		}
 	}
 }
@@ -268,34 +329,37 @@ func (t *PathTrie) lookupSegments(segments []string) []string {
 			continue
 		}
 
-		// If node is collapsed, use wildcard
-		if current.collapsed {
+		// If node is hard collapsed, use wildcard
+		if current.hardCollapsed {
 			result = append(result, t.cfg.ReplaceWith)
 			current = current.children[t.cfg.ReplaceWith]
 			if current == nil {
-				// Can't traverse further, append remaining as-is
 				result = append(result, segments[i+1:]...)
 				break
 			}
 			continue
 		}
 
-		// Try to find exact match
+		// Try to find exact match first
 		child, exists := current.children[segment]
-		if !exists {
-			// No exact match, check for wildcard
+		if exists {
+			result = append(result, segment)
+			current = child
+			continue
+		}
+
+		// If soft collapsed, check for wildcard
+		if current.softCollapsed {
 			if wildcardChild, hasWildcard := current.children[t.cfg.ReplaceWith]; hasWildcard {
 				result = append(result, t.cfg.ReplaceWith)
 				current = wildcardChild
 				continue
 			}
-			// Not found at all, append remaining segments as-is
-			result = append(result, segments[i:]...)
-			break
 		}
 
-		result = append(result, segment)
-		current = child
+		// Not found at all, append remaining segments as-is
+		result = append(result, segments[i:]...)
+		break
 	}
 
 	return result

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -1,0 +1,335 @@
+package trie
+
+import (
+	"math"
+	"strings"
+	"sync"
+)
+
+// pathNode represents a single segment in the URL path trie.
+type pathNode struct {
+	// segment is the path segment this node represents (e.g., "api", "users", "*")
+	segment string
+
+	// children maps segment strings to child nodes
+	children map[string]*pathNode
+
+	// collapsed indicates if this node's children have been collapsed to a wildcard
+	collapsed bool
+
+	// cardinality tracks the number of distinct children observed
+	cardinality int
+
+	// isWildcard indicates if this node represents a collapsed wildcard
+	isWildcard bool
+}
+
+// PathTrie is a thread-safe trie for clustering URL paths.
+// It dynamically collapses high-cardinality segments into wildcards.
+type PathTrie struct {
+	root *pathNode
+	mu   sync.RWMutex
+	cfg  *TrieConfig
+}
+
+// NewPathTrie creates a new PathTrie with the given configuration.
+// If config is nil, DefaultTrieConfig() is used.
+func NewPathTrie(config *TrieConfig) (*PathTrie, error) {
+	if config == nil {
+		config = DefaultTrieConfig()
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &PathTrie{
+		root: &pathNode{
+			segment:  "",
+			children: make(map[string]*pathNode),
+		},
+		cfg: config,
+	}, nil
+}
+
+// getMaxCardinality returns the max cardinality for a given depth.
+// It checks DepthCardinalities first, then falls back to DefaultMaxCardinality.
+// A value of -1 in DepthCardinalities means no limit (never collapse).
+func (t *PathTrie) getMaxCardinality(depth int) int {
+	if t.cfg.DepthCardinalities != nil {
+		if card, ok := t.cfg.DepthCardinalities[depth]; ok {
+			if card == -1 {
+				return math.MaxInt
+			}
+			return card
+		}
+	}
+	return t.cfg.DefaultMaxCardinality
+}
+
+// parsePath splits a path into segments, handling query strings and edge cases.
+func (t *PathTrie) parsePath(path string) []string {
+	// Strip query string
+	if idx := strings.Index(path, "?"); idx >= 0 {
+		path = path[:idx]
+	}
+
+	// Handle HTTP method prefix (e.g., "GET /path")
+	if idx := strings.Index(path, " "); idx > 0 {
+		op := path[:idx]
+		if isHTTPMethod(op) && idx < len(path) {
+			path = path[idx+1:]
+		}
+	}
+
+	// Trim leading/trailing separators and split
+	path = strings.Trim(path, t.cfg.Separator)
+	if path == "" {
+		return nil
+	}
+
+	return strings.Split(path, t.cfg.Separator)
+}
+
+// isHTTPMethod checks if the string is an HTTP method.
+func isHTTPMethod(op string) bool {
+	switch op {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD":
+		return true
+	}
+	return false
+}
+
+// Insert adds a path to the trie and returns the normalized/clustered path.
+// If a segment exceeds maxCardinality, it collapses to the wildcard.
+// Thread-safe.
+func (t *PathTrie) Insert(path string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	segments := t.parsePath(path)
+	if len(segments) == 0 {
+		return path
+	}
+
+	result := t.insertSegments(segments)
+	return t.cfg.Separator + strings.Join(result, t.cfg.Separator)
+}
+
+// insertSegments inserts segments into the trie and returns the resulting path.
+func (t *PathTrie) insertSegments(segments []string) []string {
+	current := t.root
+	result := make([]string, 0, len(segments))
+
+	for depth, segment := range segments {
+		if segment == "" {
+			result = append(result, segment)
+			continue
+		}
+
+		// If we're beyond max depth, just append segments as-is
+		if depth >= t.cfg.MaxDepth {
+			result = append(result, segments[depth:]...)
+			break
+		}
+
+		// If current node is already collapsed, all children become wildcards
+		if current.collapsed {
+			result = append(result, t.cfg.ReplaceWith)
+			// Continue with the wildcard child
+			if current.children[t.cfg.ReplaceWith] == nil {
+				current.children[t.cfg.ReplaceWith] = &pathNode{
+					segment:    t.cfg.ReplaceWith,
+					children:   make(map[string]*pathNode),
+					isWildcard: true,
+				}
+			}
+			current = current.children[t.cfg.ReplaceWith]
+			continue
+		}
+
+		// Check if this segment already exists
+		child, exists := current.children[segment]
+
+		if !exists {
+			maxCard := t.getMaxCardinality(depth)
+
+			// New segment - check if we need to collapse
+			if current.cardinality >= maxCard {
+				// Collapse this level
+				t.collapseNode(current)
+				result = append(result, t.cfg.ReplaceWith)
+				current = current.children[t.cfg.ReplaceWith]
+				continue
+			}
+
+			// Create new child
+			child = &pathNode{
+				segment:  segment,
+				children: make(map[string]*pathNode),
+			}
+			current.children[segment] = child
+			current.cardinality++
+
+			// Check if we just hit the threshold
+			if current.cardinality > maxCard {
+				t.collapseNode(current)
+				result = append(result, t.cfg.ReplaceWith)
+				current = current.children[t.cfg.ReplaceWith]
+				continue
+			}
+		}
+
+		result = append(result, segment)
+		current = child
+	}
+
+	return result
+}
+
+// collapseNode collapses a node by replacing all children with a single wildcard
+// and merging their children into the wildcard node.
+func (t *PathTrie) collapseNode(node *pathNode) {
+	if node.collapsed {
+		return
+	}
+
+	node.collapsed = true
+
+	// Create or get wildcard node
+	wildcardNode, hasWildcard := node.children[t.cfg.ReplaceWith]
+	if !hasWildcard {
+		wildcardNode = &pathNode{
+			segment:    t.cfg.ReplaceWith,
+			children:   make(map[string]*pathNode),
+			isWildcard: true,
+		}
+	}
+
+	// Merge all children into the wildcard node
+	for segment, child := range node.children {
+		if segment == t.cfg.ReplaceWith {
+			continue // Skip the wildcard itself
+		}
+		t.mergeChildren(wildcardNode, child)
+	}
+
+	// Replace all children with just the wildcard
+	node.children = map[string]*pathNode{
+		t.cfg.ReplaceWith: wildcardNode,
+	}
+	node.cardinality = 1
+
+	// Recursively check if wildcard node needs collapsing
+	// Use depth 0 for the wildcard node's children since we don't track depth in nodes
+	if wildcardNode.cardinality > t.cfg.DefaultMaxCardinality {
+		t.collapseNode(wildcardNode)
+	}
+}
+
+// mergeChildren merges children from source into target.
+// This is called during collapse to combine all child paths.
+func (t *PathTrie) mergeChildren(target, source *pathNode) {
+	for segment, child := range source.children {
+		if existing, exists := target.children[segment]; exists {
+			// Child already exists, recursively merge their children
+			t.mergeChildren(existing, child)
+		} else {
+			// New child, add it
+			target.children[segment] = child
+			target.cardinality++
+		}
+	}
+}
+
+// Lookup returns the clustered representation of a path without modifying the trie.
+// Thread-safe.
+func (t *PathTrie) Lookup(path string) string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	segments := t.parsePath(path)
+	if len(segments) == 0 {
+		return path
+	}
+
+	result := t.lookupSegments(segments)
+	return t.cfg.Separator + strings.Join(result, t.cfg.Separator)
+}
+
+// lookupSegments traverses the trie and returns the path with wildcards applied.
+func (t *PathTrie) lookupSegments(segments []string) []string {
+	current := t.root
+	result := make([]string, 0, len(segments))
+
+	for i, segment := range segments {
+		if segment == "" {
+			result = append(result, segment)
+			continue
+		}
+
+		// If node is collapsed, use wildcard
+		if current.collapsed {
+			result = append(result, t.cfg.ReplaceWith)
+			current = current.children[t.cfg.ReplaceWith]
+			if current == nil {
+				// Can't traverse further, append remaining as-is
+				result = append(result, segments[i+1:]...)
+				break
+			}
+			continue
+		}
+
+		// Try to find exact match
+		child, exists := current.children[segment]
+		if !exists {
+			// No exact match, check for wildcard
+			if wildcardChild, hasWildcard := current.children[t.cfg.ReplaceWith]; hasWildcard {
+				result = append(result, t.cfg.ReplaceWith)
+				current = wildcardChild
+				continue
+			}
+			// Not found at all, append remaining segments as-is
+			result = append(result, segments[i:]...)
+			break
+		}
+
+		result = append(result, segment)
+		current = child
+	}
+
+	return result
+}
+
+// Reset clears all nodes from the trie, resetting it to initial state.
+// Thread-safe.
+func (t *PathTrie) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.root = &pathNode{
+		segment:  "",
+		children: make(map[string]*pathNode),
+	}
+}
+
+// NodeCount returns the approximate number of nodes in the trie.
+// Thread-safe.
+func (t *PathTrie) NodeCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.countNodes(t.root)
+}
+
+// countNodes recursively counts all nodes in the subtree.
+func (t *PathTrie) countNodes(node *pathNode) int {
+	if node == nil {
+		return 0
+	}
+	count := 1
+	for _, child := range node.children {
+		count += t.countNodes(child)
+	}
+	return count
+}

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -500,3 +500,174 @@ func BenchmarkPathTrie_InsertWithCollapse(b *testing.B) {
 		}
 	}
 }
+
+// Tests for global pattern limit (MaxPatterns)
+
+func TestPathTrie_MaxPatterns_UnderLimit(t *testing.T) {
+	// Test that patterns under the limit are not affected
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 5,
+		HardMaxCardinality: 100,
+		MaxPatterns:        20,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Insert paths that create patterns under the limit
+	for i := 0; i < 5; i++ {
+		trie.Insert("/api/v" + strconv.Itoa(i) + "/users")
+	}
+
+	// All should be explicit since under both soft threshold and max patterns
+	for i := 0; i < 5; i++ {
+		result := trie.Lookup("/api/v" + strconv.Itoa(i) + "/users")
+		assert.Contains(t, result, "v"+strconv.Itoa(i), "should remain explicit when under limits")
+	}
+
+	assert.LessOrEqual(t, trie.PatternCount(), 20, "pattern count should be under limit")
+}
+
+func TestPathTrie_MaxPatterns_EnforceLimit(t *testing.T) {
+	// Test that exceeding MaxPatterns triggers hard collapse of deepest nodes
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 3,
+		HardMaxCardinality: 100, // High hard limit so it doesn't interfere
+		MaxPatterns:        10,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Insert many paths at different depths to create many patterns
+	// These will create paths like /a/b1/c1, /a/b1/c2, etc.
+	for i := 0; i < 4; i++ {
+		for j := 0; j < 4; j++ {
+			trie.Insert("/a/b" + strconv.Itoa(i) + "/c" + strconv.Itoa(j))
+		}
+	}
+
+	// Pattern count should be enforced to stay at or below MaxPatterns
+	assert.LessOrEqual(t, trie.PatternCount(), 10, "pattern count should not exceed MaxPatterns")
+}
+
+func TestPathTrie_MaxPatterns_DeepestCollapsedFirst(t *testing.T) {
+	// Test that deeper soft-collapsed nodes are hard-collapsed before shallower ones
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 100,
+		MaxPatterns:        5,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Create a structure with soft-collapsed nodes at different depths
+	// First, create explicit paths at depth 1 (under soft threshold)
+	trie.Insert("/api/v1/resource/item1")
+	trie.Insert("/api/v1/resource/item2")
+	trie.Insert("/api/v2/resource/item1")
+	trie.Insert("/api/v2/resource/item2")
+
+	// These will cause soft collapse at depth 2 (under /api/v1/resource/)
+	trie.Insert("/api/v1/resource/item3")
+	trie.Insert("/api/v1/resource/item4")
+
+	// When pattern limit is exceeded, deeper nodes should collapse first
+	// The node at depth 2 (resource level) should collapse before depth 1
+	patternCount := trie.PatternCount()
+	assert.LessOrEqual(t, patternCount, 5, "pattern count should be enforced")
+}
+
+func TestPathTrie_MaxPatterns_NoLimitWithZero(t *testing.T) {
+	// Test that MaxPatterns=0 means no limit
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 3,
+		HardMaxCardinality: 100,
+		MaxPatterns:        0, // No limit
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Insert many paths
+	for i := 0; i < 20; i++ {
+		trie.Insert("/segment" + strconv.Itoa(i) + "/sub")
+	}
+
+	// With no pattern limit, soft collapse should still happen at threshold 3
+	// but no global enforcement
+	// First 3 are explicit, rest go to wildcard but patterns still grow
+	assert.Greater(t, trie.PatternCount(), 0, "should have some patterns")
+}
+
+func TestPathTrie_MaxPatterns_NoCandidates(t *testing.T) {
+	// Test that if there are no soft-collapsed candidates, we accept over limit
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100, // Very high so nothing soft collapses
+		HardMaxCardinality: 200,
+		MaxPatterns:        5,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Insert paths - none will soft collapse since soft threshold is high
+	for i := 0; i < 10; i++ {
+		trie.Insert("/api/v" + strconv.Itoa(i))
+	}
+
+	// Since no nodes are soft-collapsed, there are no candidates to collapse
+	// Pattern count may exceed limit
+	assert.Equal(t, 10, trie.PatternCount(), "should have 10 patterns with no collapse candidates")
+}
+
+func TestPathTrie_MaxPatterns_ValidationNegative(t *testing.T) {
+	// Test that negative MaxPatterns is rejected
+	_, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 10,
+		HardMaxCardinality: 100,
+		MaxPatterns:        -1,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	assert.Error(t, err, "negative MaxPatterns should be rejected")
+	assert.Contains(t, err.Error(), "MaxPatterns")
+}
+
+func TestPathTrie_PatternCount(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, trie.PatternCount(), "empty trie should have 0 patterns")
+
+	trie.Insert("/a")
+	assert.Equal(t, 1, trie.PatternCount(), "one path should create one pattern")
+
+	trie.Insert("/b")
+	assert.Equal(t, 2, trie.PatternCount(), "two paths should create two patterns")
+
+	trie.Insert("/a/b")
+	// /a becomes a waypoint, /a/b is the leaf
+	// /b is still a leaf
+	// So we have: /a/b, /b = 2 patterns? No, /a is still a potential endpoint
+	// Actually, patterns = leaves, and /a might not be a leaf anymore if it has children
+	// Let's check: after /a/b, node "a" has child "b", so "a" is not a leaf
+	// Patterns = /a/b (1) + /b (1) = 2
+	// Wait, before we had /a as a leaf. Now /a has a child, so it's not a leaf.
+	// So pattern count should still be 2: /a/b and /b
+	assert.Equal(t, 2, trie.PatternCount(), "pattern count after adding child")
+}

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -14,87 +14,120 @@ func TestNewPathTrie(t *testing.T) {
 		trie, err := NewPathTrie(nil)
 		require.NoError(t, err)
 		assert.NotNil(t, trie)
-		assert.Equal(t, 100, trie.cfg.DefaultMaxCardinality)
+		assert.Equal(t, 10, trie.cfg.SoftMaxCardinality)
+		assert.Equal(t, 100, trie.cfg.HardMaxCardinality)
 	})
 
 	t.Run("custom config", func(t *testing.T) {
 		cfg := &TrieConfig{
-			DefaultMaxCardinality: 50,
-			ReplaceWith:           "?",
-			Separator:             "/",
-			MaxDepth:              10,
+			SoftMaxCardinality: 5,
+			HardMaxCardinality: 50,
+			ReplaceWith:        "?",
+			Separator:          "/",
+			MaxDepth:           10,
 		}
 		trie, err := NewPathTrie(cfg)
 		require.NoError(t, err)
-		assert.Equal(t, 50, trie.cfg.DefaultMaxCardinality)
-		assert.Equal(t, "?", trie.cfg.ReplaceWith)
+		assert.Equal(t, 5, trie.cfg.SoftMaxCardinality)
+		assert.Equal(t, 50, trie.cfg.HardMaxCardinality)
 	})
 
 	t.Run("invalid config returns error", func(t *testing.T) {
 		cfg := &TrieConfig{
-			DefaultMaxCardinality: 0, // invalid
-			ReplaceWith:           "*",
-			Separator:             "/",
-			MaxDepth:              20,
+			SoftMaxCardinality: 0, // invalid
+			HardMaxCardinality: 100,
+			ReplaceWith:        "*",
+			Separator:          "/",
+			MaxDepth:           20,
+		}
+		_, err := NewPathTrie(cfg)
+		assert.Error(t, err)
+	})
+
+	t.Run("hard less than soft returns error", func(t *testing.T) {
+		cfg := &TrieConfig{
+			SoftMaxCardinality: 50,
+			HardMaxCardinality: 10, // invalid: less than soft
+			ReplaceWith:        "*",
+			Separator:          "/",
+			MaxDepth:           20,
 		}
 		_, err := NewPathTrie(cfg)
 		assert.Error(t, err)
 	})
 }
 
-func TestPathTrie_BasicInsertAndLookup(t *testing.T) {
+func TestPathTrie_SoftThreshold(t *testing.T) {
+	// Soft=3, Hard=10: First 3 children explicit, 4th+ go to wildcard
 	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 2,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
+		SoftMaxCardinality: 3,
+		HardMaxCardinality: 10,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
 	})
 	require.NoError(t, err)
 
-	// Insert first path
-	result := trie.Insert("test/bar-attach-generic-product-apjkmyp/files/multi-test-version-jwbCm/test")
-	assert.Equal(t, "/test/bar-attach-generic-product-apjkmyp/files/multi-test-version-jwbCm/test", result)
-
-	// Insert second path with different second segment
-	result = trie.Insert("test/apjkmyp/files/jwbCm/test")
-	assert.Equal(t, "/test/apjkmyp/files/jwbCm/test", result)
-
-	// Insert third path - should trigger collapse at second segment (cardinality > 2)
-	result = trie.Insert("test/xyz/files/abc/test")
-	assert.Equal(t, "/test/*/files/*/test", result)
-
-	// Lookup should now return collapsed path
-	result = trie.Lookup("test/anything-new/files/something/test")
-	assert.Equal(t, "/test/*/files/*/test", result)
-}
-
-func TestPathTrie_CardinalityThreshold(t *testing.T) {
-	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 3,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
-	})
-	require.NoError(t, err)
-
-	// Add paths up to threshold
+	// First 3 should be explicit
 	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
 	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
 	assert.Equal(t, "/api/v3/users", trie.Insert("api/v3/users"))
 
-	// Next insert should trigger collapse
+	// 4th should go to wildcard (soft collapse)
 	assert.Equal(t, "/api/*/users", trie.Insert("api/v4/users"))
 
-	// Verify lookup uses collapsed path
+	// But existing paths should still be explicit
+	assert.Equal(t, "/api/v1/users", trie.Lookup("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Lookup("api/v2/users"))
+	assert.Equal(t, "/api/v3/users", trie.Lookup("api/v3/users"))
+
+	// New paths should go to wildcard
+	assert.Equal(t, "/api/*/users", trie.Lookup("api/v5/users"))
 	assert.Equal(t, "/api/*/users", trie.Lookup("api/v999/users"))
 }
 
-func TestPathTrie_DepthBasedCardinality(t *testing.T) {
+func TestPathTrie_HardThreshold(t *testing.T) {
+	// Soft=2, Hard=5: After 5 unique children, everything collapses
 	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 2,
-		DepthCardinalities: map[int]int{
-			0: 5, // First segment allows 5 unique values
-			1: 3, // Second segment allows 3 unique values
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 5,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// First 2 explicit
+	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
+
+	// Next go to wildcard (soft collapse)
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v3/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v4/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v5/users"))
+
+	// v1 and v2 should still be explicit
+	assert.Equal(t, "/api/v1/users", trie.Lookup("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Lookup("api/v2/users"))
+
+	// 6th unique triggers hard collapse - now even v1, v2 become wildcard
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v6/users"))
+
+	// Now ALL lookups should return wildcard
+	assert.Equal(t, "/api/*/users", trie.Lookup("api/v1/users"))
+	assert.Equal(t, "/api/*/users", trie.Lookup("api/v2/users"))
+	assert.Equal(t, "/api/*/users", trie.Lookup("api/v999/users"))
+}
+
+func TestPathTrie_DepthBasedThresholds(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 5,
+		DepthSoftCardinalities: map[int]int{
+			0: 5, // First segment allows 5 explicit
+		},
+		DepthHardCardinalities: map[int]int{
+			0: 20, // First segment allows 20 before hard collapse
 		},
 		ReplaceWith: "*",
 		Separator:   "/",
@@ -102,22 +135,32 @@ func TestPathTrie_DepthBasedCardinality(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Add 5 different first segments - should not collapse
+	// Add 5 different first segments - should all be explicit
 	for i := 0; i < 5; i++ {
 		result := trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
 		assert.Contains(t, result, "segment"+strconv.Itoa(i))
 	}
 
-	// 6th first segment should trigger collapse
+	// 6th first segment should go to wildcard (soft collapse at depth 0)
 	result := trie.Insert("segment5/sub/path")
 	assert.Equal(t, "/*/sub/path", result)
+
+	// But first 5 should still be explicit
+	for i := 0; i < 5; i++ {
+		result := trie.Lookup("segment" + strconv.Itoa(i) + "/sub/path")
+		assert.Contains(t, result, "segment"+strconv.Itoa(i))
+	}
 }
 
-func TestPathTrie_DepthBasedCardinality_NoLimit(t *testing.T) {
+func TestPathTrie_NoLimitWithMinusOne(t *testing.T) {
 	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 2,
-		DepthCardinalities: map[int]int{
-			0: -1, // First segment never collapses
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 5,
+		DepthSoftCardinalities: map[int]int{
+			0: -1, // First segment never soft collapses
+		},
+		DepthHardCardinalities: map[int]int{
+			0: -1, // First segment never hard collapses
 		},
 		ReplaceWith: "*",
 		Separator:   "/",
@@ -125,17 +168,21 @@ func TestPathTrie_DepthBasedCardinality_NoLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Add many first segments - should never collapse due to -1
+	// Add many first segments - should never collapse
 	for i := 0; i < 100; i++ {
 		result := trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
 		assert.Contains(t, result, "segment"+strconv.Itoa(i), "depth 0 should never collapse with -1")
 	}
 
-	// But second level should still collapse at 2
+	// But second level should still collapse at soft=2
 	trie2, _ := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 2,
-		DepthCardinalities: map[int]int{
-			0: -1, // First segment never collapses
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 5,
+		DepthSoftCardinalities: map[int]int{
+			0: -1,
+		},
+		DepthHardCardinalities: map[int]int{
+			0: -1,
 		},
 		ReplaceWith: "*",
 		Separator:   "/",
@@ -145,31 +192,11 @@ func TestPathTrie_DepthBasedCardinality_NoLimit(t *testing.T) {
 	trie2.Insert("api/v1/users")
 	trie2.Insert("api/v2/users")
 	result := trie2.Insert("api/v3/users")
-	assert.Equal(t, "/api/*/users", result, "depth 1 should still collapse at default cardinality")
-}
+	assert.Equal(t, "/api/*/users", result, "depth 1 should still soft collapse")
 
-func TestPathTrie_CascadingCollapse(t *testing.T) {
-	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 2,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
-	})
-	require.NoError(t, err)
-
-	// Build tree: /root/child1/grandchild1
-	//             /root/child1/grandchild2
-	//             /root/child2/grandchild3
-	trie.Insert("root/child1/grandchild1")
-	trie.Insert("root/child1/grandchild2")
-	trie.Insert("root/child2/grandchild3")
-
-	// This should trigger collapse at "child" level
-	// which should cascade to grandchildren
-	result := trie.Insert("root/child3/grandchild4")
-
-	// After collapse, all should be wildcards
-	assert.Equal(t, "/root/*/*", result)
+	// v1 and v2 should still be explicit
+	assert.Equal(t, "/api/v1/users", trie2.Lookup("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie2.Lookup("api/v2/users"))
 }
 
 func TestPathTrie_EmptyPath(t *testing.T) {
@@ -191,17 +218,6 @@ func TestPathTrie_SingleSegment(t *testing.T) {
 	assert.Equal(t, "/test", result)
 }
 
-func TestPathTrie_TrailingSlash(t *testing.T) {
-	trie, err := NewPathTrie(nil)
-	require.NoError(t, err)
-
-	result1 := trie.Insert("/api/users/")
-	result2 := trie.Insert("/api/users")
-
-	// Both should normalize to the same path
-	assert.Equal(t, result1, result2)
-}
-
 func TestPathTrie_QueryString(t *testing.T) {
 	trie, err := NewPathTrie(nil)
 	require.NoError(t, err)
@@ -221,31 +237,6 @@ func TestPathTrie_HTTPMethodPrefix(t *testing.T) {
 	// Non-HTTP prefix should be preserved
 	result = trie.Insert("MET /user_space")
 	assert.Equal(t, "/MET /user_space", result)
-}
-
-func TestPathTrie_PreserveExistingPaths(t *testing.T) {
-	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 2,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
-	})
-	require.NoError(t, err)
-
-	// Insert paths
-	trie.Insert("api/users/123")
-	trie.Insert("api/users/456")
-
-	// Before collapse, lookups should return exact matches
-	assert.Equal(t, "/api/users/123", trie.Lookup("api/users/123"))
-	assert.Equal(t, "/api/users/456", trie.Lookup("api/users/456"))
-
-	// Trigger collapse
-	trie.Insert("api/users/789")
-
-	// After collapse, all should use wildcard
-	assert.Equal(t, "/api/users/*", trie.Lookup("api/users/123"))
-	assert.Equal(t, "/api/users/*", trie.Lookup("api/users/999"))
 }
 
 func TestPathTrie_Reset(t *testing.T) {
@@ -277,10 +268,11 @@ func TestPathTrie_NodeCount(t *testing.T) {
 
 func TestPathTrie_Concurrent(t *testing.T) {
 	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 10,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
+		SoftMaxCardinality: 10,
+		HardMaxCardinality: 100,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
 	})
 	require.NoError(t, err)
 
@@ -307,52 +299,31 @@ func TestPathTrie_Concurrent(t *testing.T) {
 	assert.NotEmpty(t, result)
 }
 
-func TestPathTrie_MaxDepth(t *testing.T) {
+func TestPathTrie_CascadingCollapse(t *testing.T) {
 	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 100,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              3,
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 3,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
 	})
 	require.NoError(t, err)
 
-	// Path with more segments than MaxDepth
-	result := trie.Insert("/a/b/c/d/e/f")
-	assert.Equal(t, "/a/b/c/d/e/f", result)
+	// Build tree with multiple branches
+	trie.Insert("root/child1/grandchild1")
+	trie.Insert("root/child1/grandchild2")
+	trie.Insert("root/child2/grandchild3")
 
-	// Segments beyond MaxDepth are preserved
-	result = trie.Lookup("/a/b/c/x/y/z")
-	assert.Equal(t, "/a/b/c/x/y/z", result)
-}
+	// This triggers soft collapse at child level
+	trie.Insert("root/child3/grandchild4")
 
-func TestPathTrie_ComplexPaths(t *testing.T) {
-	trie, err := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 3,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
-	})
-	require.NoError(t, err)
+	// Trigger hard collapse
+	result := trie.Insert("root/child4/grandchild5")
+	assert.Equal(t, "/root/*/*", result)
 
-	paths := []string{
-		"bar/test/test/bar-attach-generic-product-apjkmyp/files/multi-test-version-jwbCm/test",
-		"bar/test/test/bar-attach-generic-registry-apjkmyp/files/push-metrics-test-OYboK/test",
-		"bar/test/test/another-product-xyz/files/version-abc/test",
-	}
-
-	for _, path := range paths {
-		trie.Insert(path)
-	}
-
-	// Should not collapse yet (cardinality = 3, threshold = 3)
-	result := trie.Lookup(paths[0])
-	assert.Contains(t, result, "bar-attach-generic-product-apjkmyp")
-
-	// Fourth path should trigger collapse
-	trie.Insert("bar/test/test/fourth-product/files/version-def/test")
-
-	result = trie.Lookup("bar/test/test/any-product/files/any-version/test")
-	assert.Equal(t, "/bar/test/test/*/files/*/test", result)
+	// After hard collapse, all lookups should return wildcard
+	assert.Equal(t, "/root/*/*", trie.Lookup("root/child1/grandchild1"))
+	assert.Equal(t, "/root/*/*", trie.Lookup("root/anything/else"))
 }
 
 func TestTrieConfig_Validate(t *testing.T) {
@@ -367,117 +338,72 @@ func TestTrieConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "zero cardinality",
+			name: "zero soft cardinality",
 			config: &TrieConfig{
-				DefaultMaxCardinality: 0,
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              20,
+				SoftMaxCardinality: 0,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
 			},
 			wantErr: true,
 		},
 		{
-			name: "negative cardinality",
+			name: "zero hard cardinality",
 			config: &TrieConfig{
-				DefaultMaxCardinality: -1,
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              20,
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 0,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "hard less than soft",
+			config: &TrieConfig{
+				SoftMaxCardinality: 50,
+				HardMaxCardinality: 10,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
 			},
 			wantErr: true,
 		},
 		{
 			name: "empty replace with",
 			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				ReplaceWith:           "",
-				Separator:             "/",
-				MaxDepth:              20,
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "",
+				Separator:          "/",
+				MaxDepth:           20,
 			},
 			wantErr: true,
 		},
 		{
-			name: "empty separator",
+			name: "valid with depth overrides",
 			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				ReplaceWith:           "*",
-				Separator:             "",
-				MaxDepth:              20,
-			},
-			wantErr: true,
-		},
-		{
-			name: "zero max depth",
-			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              0,
-			},
-			wantErr: true,
-		},
-		{
-			name: "max depth too large",
-			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              101,
-			},
-			wantErr: true,
-		},
-		{
-			name: "negative depth in DepthCardinalities",
-			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				DepthCardinalities:    map[int]int{-1: 50},
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              20,
-			},
-			wantErr: true,
-		},
-		{
-			name: "zero cardinality in DepthCardinalities",
-			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				DepthCardinalities:    map[int]int{0: 0},
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              20,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid negative cardinality in DepthCardinalities",
-			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				DepthCardinalities:    map[int]int{0: -2},
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              20,
-			},
-			wantErr: true,
-		},
-		{
-			name: "valid depth cardinalities",
-			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				DepthCardinalities:    map[int]int{0: 50, 1: 30, 2: 20},
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              20,
+				SoftMaxCardinality:     10,
+				HardMaxCardinality:     100,
+				DepthSoftCardinalities: map[int]int{0: 5, 1: 3},
+				DepthHardCardinalities: map[int]int{0: 50, 1: 30},
+				ReplaceWith:            "*",
+				Separator:              "/",
+				MaxDepth:               20,
 			},
 			wantErr: false,
 		},
 		{
 			name: "-1 for no limit is valid",
 			config: &TrieConfig{
-				DefaultMaxCardinality: 100,
-				DepthCardinalities:    map[int]int{0: -1, 1: 50},
-				ReplaceWith:           "*",
-				Separator:             "/",
-				MaxDepth:              20,
+				SoftMaxCardinality:     10,
+				HardMaxCardinality:     100,
+				DepthSoftCardinalities: map[int]int{0: -1},
+				DepthHardCardinalities: map[int]int{0: -1},
+				ReplaceWith:            "*",
+				Separator:              "/",
+				MaxDepth:               20,
 			},
 			wantErr: false,
 		},
@@ -499,10 +425,11 @@ func TestTrieConfig_Validate(t *testing.T) {
 
 func BenchmarkPathTrie_Insert(b *testing.B) {
 	trie, _ := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 100,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
+		SoftMaxCardinality: 10,
+		HardMaxCardinality: 100,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
 	})
 
 	paths := []string{
@@ -526,10 +453,11 @@ func BenchmarkPathTrie_Insert(b *testing.B) {
 
 func BenchmarkPathTrie_Lookup(b *testing.B) {
 	trie, _ := NewPathTrie(&TrieConfig{
-		DefaultMaxCardinality: 100,
-		ReplaceWith:           "*",
-		Separator:             "/",
-		MaxDepth:              20,
+		SoftMaxCardinality: 10,
+		HardMaxCardinality: 100,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
 	})
 
 	// Pre-populate trie
@@ -561,10 +489,11 @@ func BenchmarkPathTrie_InsertWithCollapse(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		trie, _ := NewPathTrie(&TrieConfig{
-			DefaultMaxCardinality: 10,
-			ReplaceWith:           "*",
-			Separator:             "/",
-			MaxDepth:              20,
+			SoftMaxCardinality: 10,
+			HardMaxCardinality: 50,
+			ReplaceWith:        "*",
+			Separator:          "/",
+			MaxDepth:           20,
 		})
 		for _, path := range paths {
 			trie.Insert(path)

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -1,0 +1,573 @@
+package trie
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPathTrie(t *testing.T) {
+	t.Run("nil config uses defaults", func(t *testing.T) {
+		trie, err := NewPathTrie(nil)
+		require.NoError(t, err)
+		assert.NotNil(t, trie)
+		assert.Equal(t, 100, trie.cfg.DefaultMaxCardinality)
+	})
+
+	t.Run("custom config", func(t *testing.T) {
+		cfg := &TrieConfig{
+			DefaultMaxCardinality: 50,
+			ReplaceWith:           "?",
+			Separator:             "/",
+			MaxDepth:              10,
+		}
+		trie, err := NewPathTrie(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, 50, trie.cfg.DefaultMaxCardinality)
+		assert.Equal(t, "?", trie.cfg.ReplaceWith)
+	})
+
+	t.Run("invalid config returns error", func(t *testing.T) {
+		cfg := &TrieConfig{
+			DefaultMaxCardinality: 0, // invalid
+			ReplaceWith:           "*",
+			Separator:             "/",
+			MaxDepth:              20,
+		}
+		_, err := NewPathTrie(cfg)
+		assert.Error(t, err)
+	})
+}
+
+func TestPathTrie_BasicInsertAndLookup(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 2,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+	require.NoError(t, err)
+
+	// Insert first path
+	result := trie.Insert("test/bar-attach-generic-product-apjkmyp/files/multi-test-version-jwbCm/test")
+	assert.Equal(t, "/test/bar-attach-generic-product-apjkmyp/files/multi-test-version-jwbCm/test", result)
+
+	// Insert second path with different second segment
+	result = trie.Insert("test/apjkmyp/files/jwbCm/test")
+	assert.Equal(t, "/test/apjkmyp/files/jwbCm/test", result)
+
+	// Insert third path - should trigger collapse at second segment (cardinality > 2)
+	result = trie.Insert("test/xyz/files/abc/test")
+	assert.Equal(t, "/test/*/files/*/test", result)
+
+	// Lookup should now return collapsed path
+	result = trie.Lookup("test/anything-new/files/something/test")
+	assert.Equal(t, "/test/*/files/*/test", result)
+}
+
+func TestPathTrie_CardinalityThreshold(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 3,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+	require.NoError(t, err)
+
+	// Add paths up to threshold
+	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
+	assert.Equal(t, "/api/v3/users", trie.Insert("api/v3/users"))
+
+	// Next insert should trigger collapse
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v4/users"))
+
+	// Verify lookup uses collapsed path
+	assert.Equal(t, "/api/*/users", trie.Lookup("api/v999/users"))
+}
+
+func TestPathTrie_DepthBasedCardinality(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 2,
+		DepthCardinalities: map[int]int{
+			0: 5, // First segment allows 5 unique values
+			1: 3, // Second segment allows 3 unique values
+		},
+		ReplaceWith: "*",
+		Separator:   "/",
+		MaxDepth:    20,
+	})
+	require.NoError(t, err)
+
+	// Add 5 different first segments - should not collapse
+	for i := 0; i < 5; i++ {
+		result := trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
+		assert.Contains(t, result, "segment"+strconv.Itoa(i))
+	}
+
+	// 6th first segment should trigger collapse
+	result := trie.Insert("segment5/sub/path")
+	assert.Equal(t, "/*/sub/path", result)
+}
+
+func TestPathTrie_DepthBasedCardinality_NoLimit(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 2,
+		DepthCardinalities: map[int]int{
+			0: -1, // First segment never collapses
+		},
+		ReplaceWith: "*",
+		Separator:   "/",
+		MaxDepth:    20,
+	})
+	require.NoError(t, err)
+
+	// Add many first segments - should never collapse due to -1
+	for i := 0; i < 100; i++ {
+		result := trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
+		assert.Contains(t, result, "segment"+strconv.Itoa(i), "depth 0 should never collapse with -1")
+	}
+
+	// But second level should still collapse at 2
+	trie2, _ := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 2,
+		DepthCardinalities: map[int]int{
+			0: -1, // First segment never collapses
+		},
+		ReplaceWith: "*",
+		Separator:   "/",
+		MaxDepth:    20,
+	})
+
+	trie2.Insert("api/v1/users")
+	trie2.Insert("api/v2/users")
+	result := trie2.Insert("api/v3/users")
+	assert.Equal(t, "/api/*/users", result, "depth 1 should still collapse at default cardinality")
+}
+
+func TestPathTrie_CascadingCollapse(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 2,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+	require.NoError(t, err)
+
+	// Build tree: /root/child1/grandchild1
+	//             /root/child1/grandchild2
+	//             /root/child2/grandchild3
+	trie.Insert("root/child1/grandchild1")
+	trie.Insert("root/child1/grandchild2")
+	trie.Insert("root/child2/grandchild3")
+
+	// This should trigger collapse at "child" level
+	// which should cascade to grandchildren
+	result := trie.Insert("root/child3/grandchild4")
+
+	// After collapse, all should be wildcards
+	assert.Equal(t, "/root/*/*", result)
+}
+
+func TestPathTrie_EmptyPath(t *testing.T) {
+	trie, err := NewPathTrie(nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, trie.Insert(""))
+	assert.Empty(t, trie.Lookup(""))
+}
+
+func TestPathTrie_SingleSegment(t *testing.T) {
+	trie, err := NewPathTrie(nil)
+	require.NoError(t, err)
+
+	result := trie.Insert("test")
+	assert.Equal(t, "/test", result)
+
+	result = trie.Lookup("test")
+	assert.Equal(t, "/test", result)
+}
+
+func TestPathTrie_TrailingSlash(t *testing.T) {
+	trie, err := NewPathTrie(nil)
+	require.NoError(t, err)
+
+	result1 := trie.Insert("/api/users/")
+	result2 := trie.Insert("/api/users")
+
+	// Both should normalize to the same path
+	assert.Equal(t, result1, result2)
+}
+
+func TestPathTrie_QueryString(t *testing.T) {
+	trie, err := NewPathTrie(nil)
+	require.NoError(t, err)
+
+	result := trie.Insert("/attach?session_id=ddfsdsf&track_id=sjdklnfldsn")
+	assert.Equal(t, "/attach", result)
+}
+
+func TestPathTrie_HTTPMethodPrefix(t *testing.T) {
+	trie, err := NewPathTrie(nil)
+	require.NoError(t, err)
+
+	// HTTP method should be stripped
+	result := trie.Insert("GET /user_space?kernel_space")
+	assert.Equal(t, "/user_space", result)
+
+	// Non-HTTP prefix should be preserved
+	result = trie.Insert("MET /user_space")
+	assert.Equal(t, "/MET /user_space", result)
+}
+
+func TestPathTrie_PreserveExistingPaths(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 2,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+	require.NoError(t, err)
+
+	// Insert paths
+	trie.Insert("api/users/123")
+	trie.Insert("api/users/456")
+
+	// Before collapse, lookups should return exact matches
+	assert.Equal(t, "/api/users/123", trie.Lookup("api/users/123"))
+	assert.Equal(t, "/api/users/456", trie.Lookup("api/users/456"))
+
+	// Trigger collapse
+	trie.Insert("api/users/789")
+
+	// After collapse, all should use wildcard
+	assert.Equal(t, "/api/users/*", trie.Lookup("api/users/123"))
+	assert.Equal(t, "/api/users/*", trie.Lookup("api/users/999"))
+}
+
+func TestPathTrie_Reset(t *testing.T) {
+	trie, err := NewPathTrie(nil)
+	require.NoError(t, err)
+
+	trie.Insert("/api/v1/users")
+	trie.Insert("/api/v2/products")
+
+	assert.Greater(t, trie.NodeCount(), 1)
+
+	trie.Reset()
+
+	assert.Equal(t, 1, trie.NodeCount()) // Only root node
+}
+
+func TestPathTrie_NodeCount(t *testing.T) {
+	trie, err := NewPathTrie(nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, trie.NodeCount()) // Root only
+
+	trie.Insert("/a/b/c")
+	assert.Equal(t, 4, trie.NodeCount()) // Root + a + b + c
+
+	trie.Insert("/a/b/d")
+	assert.Equal(t, 5, trie.NodeCount()) // Root + a + b + c + d
+}
+
+func TestPathTrie_Concurrent(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 10,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	numGoroutines := 100
+	insertsPerGoroutine := 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < insertsPerGoroutine; j++ {
+				path := "/api/v" + strconv.Itoa(id) + "/resource/" + strconv.Itoa(j)
+				trie.Insert(path)
+				trie.Lookup(path)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify trie is still functional
+	result := trie.Lookup("/api/v0/resource/0")
+	assert.NotEmpty(t, result)
+}
+
+func TestPathTrie_MaxDepth(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 100,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              3,
+	})
+	require.NoError(t, err)
+
+	// Path with more segments than MaxDepth
+	result := trie.Insert("/a/b/c/d/e/f")
+	assert.Equal(t, "/a/b/c/d/e/f", result)
+
+	// Segments beyond MaxDepth are preserved
+	result = trie.Lookup("/a/b/c/x/y/z")
+	assert.Equal(t, "/a/b/c/x/y/z", result)
+}
+
+func TestPathTrie_ComplexPaths(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 3,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+	require.NoError(t, err)
+
+	paths := []string{
+		"bar/test/test/bar-attach-generic-product-apjkmyp/files/multi-test-version-jwbCm/test",
+		"bar/test/test/bar-attach-generic-registry-apjkmyp/files/push-metrics-test-OYboK/test",
+		"bar/test/test/another-product-xyz/files/version-abc/test",
+	}
+
+	for _, path := range paths {
+		trie.Insert(path)
+	}
+
+	// Should not collapse yet (cardinality = 3, threshold = 3)
+	result := trie.Lookup(paths[0])
+	assert.Contains(t, result, "bar-attach-generic-product-apjkmyp")
+
+	// Fourth path should trigger collapse
+	trie.Insert("bar/test/test/fourth-product/files/version-def/test")
+
+	result = trie.Lookup("bar/test/test/any-product/files/any-version/test")
+	assert.Equal(t, "/bar/test/test/*/files/*/test", result)
+}
+
+func TestTrieConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *TrieConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid default config",
+			config:  DefaultTrieConfig(),
+			wantErr: false,
+		},
+		{
+			name: "zero cardinality",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 0,
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative cardinality",
+			config: &TrieConfig{
+				DefaultMaxCardinality: -1,
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty replace with",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				ReplaceWith:           "",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty separator",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				ReplaceWith:           "*",
+				Separator:             "",
+				MaxDepth:              20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero max depth",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "max depth too large",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              101,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative depth in DepthCardinalities",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				DepthCardinalities:    map[int]int{-1: 50},
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero cardinality in DepthCardinalities",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				DepthCardinalities:    map[int]int{0: 0},
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid negative cardinality in DepthCardinalities",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				DepthCardinalities:    map[int]int{0: -2},
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid depth cardinalities",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				DepthCardinalities:    map[int]int{0: 50, 1: 30, 2: 20},
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: false,
+		},
+		{
+			name: "-1 for no limit is valid",
+			config: &TrieConfig{
+				DefaultMaxCardinality: 100,
+				DepthCardinalities:    map[int]int{0: -1, 1: 50},
+				ReplaceWith:           "*",
+				Separator:             "/",
+				MaxDepth:              20,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Benchmarks
+
+func BenchmarkPathTrie_Insert(b *testing.B) {
+	trie, _ := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 100,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+
+	paths := []string{
+		"/users/fdklsd/j4elk/23993/job/2",
+		"/v1/products/22",
+		"/products/1/org/3",
+		"/attach?session_id=ddfsdsf&track_id=sjdklnfldsn",
+		"GET /user_space/",
+		"/api/hello.world",
+		"/123/ljgdflgjf",
+		"/a/b/c/d/e",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, path := range paths {
+			trie.Insert(path)
+		}
+	}
+}
+
+func BenchmarkPathTrie_Lookup(b *testing.B) {
+	trie, _ := NewPathTrie(&TrieConfig{
+		DefaultMaxCardinality: 100,
+		ReplaceWith:           "*",
+		Separator:             "/",
+		MaxDepth:              20,
+	})
+
+	// Pre-populate trie
+	paths := []string{
+		"/users/fdklsd/j4elk/23993/job/2",
+		"/v1/products/22",
+		"/products/1/org/3",
+		"/api/hello.world",
+		"/a/b/c/d/e",
+	}
+	for _, path := range paths {
+		trie.Insert(path)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, path := range paths {
+			trie.Lookup(path)
+		}
+	}
+}
+
+func BenchmarkPathTrie_InsertWithCollapse(b *testing.B) {
+	paths := make([]string, 1000)
+	for i := 0; i < 1000; i++ {
+		paths[i] = "/api/v" + strconv.Itoa(i) + "/resource/" + strconv.Itoa(i%100)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		trie, _ := NewPathTrie(&TrieConfig{
+			DefaultMaxCardinality: 10,
+			ReplaceWith:           "*",
+			Separator:             "/",
+			MaxDepth:              20,
+		})
+		for _, path := range paths {
+			trie.Insert(path)
+		}
+	}
+}

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -1,61 +1,15 @@
 package trie
 
 import (
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestNewPathTrie(t *testing.T) {
-	t.Run("nil config uses defaults", func(t *testing.T) {
-		trie, err := NewPathTrie(nil)
-		require.NoError(t, err)
-		assert.NotNil(t, trie)
-		assert.Equal(t, 10, trie.cfg.SoftMaxCardinality)
-		assert.Equal(t, 100, trie.cfg.HardMaxCardinality)
-	})
-
-	t.Run("custom config", func(t *testing.T) {
-		cfg := &TrieConfig{
-			SoftMaxCardinality: 5,
-			HardMaxCardinality: 50,
-			ReplaceWith:        "?",
-			Separator:          "/",
-			MaxDepth:           10,
-		}
-		trie, err := NewPathTrie(cfg)
-		require.NoError(t, err)
-		assert.Equal(t, 5, trie.cfg.SoftMaxCardinality)
-		assert.Equal(t, 50, trie.cfg.HardMaxCardinality)
-	})
-
-	t.Run("invalid config returns error", func(t *testing.T) {
-		cfg := &TrieConfig{
-			SoftMaxCardinality: 0, // invalid
-			HardMaxCardinality: 100,
-			ReplaceWith:        "*",
-			Separator:          "/",
-			MaxDepth:           20,
-		}
-		_, err := NewPathTrie(cfg)
-		assert.Error(t, err)
-	})
-
-	t.Run("hard less than soft returns error", func(t *testing.T) {
-		cfg := &TrieConfig{
-			SoftMaxCardinality: 50,
-			HardMaxCardinality: 10, // invalid: less than soft
-			ReplaceWith:        "*",
-			Separator:          "/",
-			MaxDepth:           20,
-		}
-		_, err := NewPathTrie(cfg)
-		assert.Error(t, err)
-	})
-}
 
 func TestPathTrie_SoftThreshold(t *testing.T) {
 	// Soft=3, Hard=10: First 3 children explicit, 4th+ go to wildcard
@@ -77,13 +31,13 @@ func TestPathTrie_SoftThreshold(t *testing.T) {
 	assert.Equal(t, "/api/*/users", trie.Insert("api/v4/users"))
 
 	// But existing paths should still be explicit
-	assert.Equal(t, "/api/v1/users", trie.Lookup("api/v1/users"))
-	assert.Equal(t, "/api/v2/users", trie.Lookup("api/v2/users"))
-	assert.Equal(t, "/api/v3/users", trie.Lookup("api/v3/users"))
+	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
+	assert.Equal(t, "/api/v3/users", trie.Insert("api/v3/users"))
 
 	// New paths should go to wildcard
-	assert.Equal(t, "/api/*/users", trie.Lookup("api/v5/users"))
-	assert.Equal(t, "/api/*/users", trie.Lookup("api/v999/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v5/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v999/users"))
 }
 
 func TestPathTrie_HardThreshold(t *testing.T) {
@@ -107,16 +61,16 @@ func TestPathTrie_HardThreshold(t *testing.T) {
 	assert.Equal(t, "/api/*/users", trie.Insert("api/v5/users"))
 
 	// v1 and v2 should still be explicit
-	assert.Equal(t, "/api/v1/users", trie.Lookup("api/v1/users"))
-	assert.Equal(t, "/api/v2/users", trie.Lookup("api/v2/users"))
+	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
 
 	// 6th unique triggers hard collapse - now even v1, v2 become wildcard
 	assert.Equal(t, "/api/*/users", trie.Insert("api/v6/users"))
 
 	// Now ALL lookups should return wildcard
-	assert.Equal(t, "/api/*/users", trie.Lookup("api/v1/users"))
-	assert.Equal(t, "/api/*/users", trie.Lookup("api/v2/users"))
-	assert.Equal(t, "/api/*/users", trie.Lookup("api/v999/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v2/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v999/users"))
 }
 
 func TestPathTrie_DepthBasedThresholds(t *testing.T) {
@@ -147,8 +101,22 @@ func TestPathTrie_DepthBasedThresholds(t *testing.T) {
 
 	// But first 5 should still be explicit
 	for i := 0; i < 5; i++ {
-		result := trie.Lookup("segment" + strconv.Itoa(i) + "/sub/path")
+		result := trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
 		assert.Contains(t, result, "segment"+strconv.Itoa(i))
+	}
+
+	// Test hard collapse limits.
+	for i := 0; i < 20; i++ {
+		trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
+	}
+	for i := 0; i < 5; i++ {
+		result := trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
+		assert.Contains(t, result, "segment"+strconv.Itoa(i))
+	}
+	trie.Insert("segment20/sub/path")
+	for i := 0; i < 5; i++ {
+		result := trie.Insert("segment" + strconv.Itoa(i) + "/sub/path")
+		assert.Equal(t, "/*/sub/path", result)
 	}
 }
 
@@ -226,19 +194,6 @@ func TestPathTrie_QueryString(t *testing.T) {
 	assert.Equal(t, "/attach", result)
 }
 
-func TestPathTrie_HTTPMethodPrefix(t *testing.T) {
-	trie, err := NewPathTrie(nil)
-	require.NoError(t, err)
-
-	// HTTP method should be stripped
-	result := trie.Insert("GET /user_space?kernel_space")
-	assert.Equal(t, "/user_space", result)
-
-	// Non-HTTP prefix should be preserved
-	result = trie.Insert("MET /user_space")
-	assert.Equal(t, "/MET /user_space", result)
-}
-
 func TestPathTrie_Reset(t *testing.T) {
 	trie, err := NewPathTrie(nil)
 	require.NoError(t, err)
@@ -299,6 +254,50 @@ func TestPathTrie_Concurrent(t *testing.T) {
 	assert.NotEmpty(t, result)
 }
 
+func TestPathTrie_HardThreshold_UniqueSegmentCounting(t *testing.T) {
+	// Verify that repeated segments don't count multiple times toward hard threshold
+	// Soft=2, Hard=5: hard collapse should only trigger after 5 UNIQUE children
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 5,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// First 2 explicit
+	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
+
+	// v3 goes to wildcard (soft collapse)
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v3/users"))
+
+	// Insert v3 many more times - should NOT count toward hard threshold
+	for i := 0; i < 100; i++ {
+		assert.Equal(t, "/api/*/users", trie.Insert("api/v3/users"))
+	}
+
+	// v1 and v2 should still be explicit (not hard collapsed yet)
+	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
+
+	// Now add v4 and v5 (still under hard threshold)
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v4/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v5/users"))
+
+	// v1 and v2 should STILL be explicit
+	assert.Equal(t, "/api/v1/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/v2/users", trie.Insert("api/v2/users"))
+
+	// v6 triggers hard collapse (6th unique child > hard threshold of 5)
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v6/users"))
+
+	// Now v1 and v2 should be wildcarded
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v1/users"))
+	assert.Equal(t, "/api/*/users", trie.Insert("api/v2/users"))
+}
+
 func TestPathTrie_CascadingCollapse(t *testing.T) {
 	trie, err := NewPathTrie(&TrieConfig{
 		SoftMaxCardinality: 2,
@@ -315,10 +314,11 @@ func TestPathTrie_CascadingCollapse(t *testing.T) {
 	trie.Insert("root/child2/grandchild3")
 
 	// This triggers soft collapse at child level
-	trie.Insert("root/child3/grandchild4")
+	result := trie.Insert("root/child3/grandchild4")
+	assert.Equal(t, "/root/*/grandchild4", result)
 
 	// Trigger hard collapse
-	result := trie.Insert("root/child4/grandchild5")
+	result = trie.Insert("root/child4/grandchild5")
 	assert.Equal(t, "/root/*/*", result)
 
 	// After hard collapse, all lookups should return wildcard
@@ -407,6 +407,96 @@ func TestTrieConfig_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "negative MaxPatterns",
+			config: &TrieConfig{
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				MaxPatterns:        -1,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid with TTL and prune interval",
+			config: &TrieConfig{
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+				PatternTTL:         time.Hour,
+				PruneInterval:      time.Minute,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with no TTL or pruning",
+			config: &TrieConfig{
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+				PatternTTL:         0,
+				PruneInterval:      0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with TTL only (no background pruning)",
+			config: &TrieConfig{
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+				PatternTTL:         time.Hour,
+				PruneInterval:      0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid prune interval without TTL",
+			config: &TrieConfig{
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+				PatternTTL:         0,
+				PruneInterval:      time.Minute,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid negative TTL",
+			config: &TrieConfig{
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+				PatternTTL:         -time.Hour,
+				PruneInterval:      0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid negative prune interval",
+			config: &TrieConfig{
+				SoftMaxCardinality: 10,
+				HardMaxCardinality: 100,
+				ReplaceWith:        "*",
+				Separator:          "/",
+				MaxDepth:           20,
+				PatternTTL:         time.Hour,
+				PruneInterval:      -time.Minute,
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -419,6 +509,396 @@ func TestTrieConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Tests for global pattern limit (MaxPatterns)
+
+func TestPathTrie_MaxPatterns_UnderLimit(t *testing.T) {
+	// Test that patterns under the limit are not affected
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 5,
+		HardMaxCardinality: 100,
+		MaxPatterns:        20,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Insert paths that create patterns under the limit
+	for i := 0; i < 5; i++ {
+		trie.Insert("/api/v" + strconv.Itoa(i) + "/users")
+	}
+
+	// All should be explicit since under both soft threshold and max patterns
+	for i := 0; i < 5; i++ {
+		result := trie.Lookup("/api/v" + strconv.Itoa(i) + "/users")
+		assert.Contains(t, result, "v"+strconv.Itoa(i), "should remain explicit when under limits")
+	}
+
+	assert.Equal(t, trie.PatternCount(), 5)
+
+	// Insert more paths, however, the patternCount() goes up by only 1 after softMax and before hardMax.
+	for i := 0; i < 100; i++ {
+		trie.Insert("/api/v" + strconv.Itoa(i) + "/users")
+	}
+	assert.Equal(t, trie.PatternCount(), 6)
+
+	trie.Insert("api/v100/users")
+	assert.Equal(t, trie.PatternCount(), 1)
+}
+
+func TestPathTrie_MaxPatterns_EnforceLimit(t *testing.T) {
+	// Test that exceeding MaxPatterns triggers hard collapse of deepest nodes
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 3,
+		HardMaxCardinality: 100, // High hard limit so it doesn't interfere
+		MaxPatterns:        10,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Insert many paths at different depths to create many patterns
+	// These will create paths like /a/b1/c1, /a/b1/c2, etc.
+	for i := 0; i < 4; i++ {
+		for j := 0; j < 4; j++ {
+			trie.Insert("/a/b" + strconv.Itoa(i) + "/c" + strconv.Itoa(j))
+		}
+	}
+
+	// Pattern count should be enforced to stay at or below MaxPatterns
+	assert.LessOrEqual(t, trie.PatternCount(), 10, "pattern count should not exceed MaxPatterns")
+}
+
+func TestPathTrie_MaxPatterns_DeepestCollapsedFirst(t *testing.T) {
+	// Test that deeper soft-collapsed nodes are hard-collapsed before shallower ones
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 2,
+		HardMaxCardinality: 100,
+		MaxPatterns:        5,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Create a structure with soft-collapsed nodes at different depths
+	// First, create explicit paths at depth 1 (under soft threshold)
+	trie.Insert("/api/v1/resource/item1")
+	trie.Insert("/api/v1/resource/item2")
+	trie.Insert("/api/v2/resource/item1")
+	trie.Insert("/api/v2/resource/item2")
+
+	// These will cause soft collapse at depth 2 (under /api/v1/resource/)
+	trie.Insert("/api/v1/resource/item3")
+	trie.Insert("/api/v1/resource/item4")
+
+	// When pattern limit is exceeded, deeper nodes should collapse first
+	// The node at depth 2 (resource level) should collapse before depth 1
+	patternCount := trie.PatternCount()
+	assert.LessOrEqual(t, patternCount, 5, "pattern count should be enforced")
+
+	result := trie.Insert("/api/v1/resource/item3")
+	assert.Equal(t, "/api/v1/resource/*", result)
+}
+
+func TestPathTrie_MaxPatterns_NoCandidates(t *testing.T) {
+	// Test that if there are no soft-collapsed candidates, we accept over limit
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100, // Very high so nothing soft collapses
+		HardMaxCardinality: 200,
+		MaxPatterns:        5,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	// Insert paths - none will soft collapse since soft threshold is high
+	for i := 0; i < 10; i++ {
+		trie.Insert("/api/v" + strconv.Itoa(i))
+	}
+
+	// Since no nodes are soft-collapsed, there are no candidates to collapse
+	// Pattern count may exceed limit
+	assert.Equal(t, 10, trie.PatternCount(), "should have 10 patterns with no collapse candidates")
+}
+
+func TestPathTrie_PatternCount(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, trie.PatternCount(), "empty trie should have 0 patterns")
+
+	trie.Insert("/a")
+	assert.Equal(t, 1, trie.PatternCount(), "one path should create one pattern")
+
+	trie.Insert("/b")
+	assert.Equal(t, 2, trie.PatternCount(), "two paths should create two patterns")
+
+	trie.Insert("/a/b")
+	// /a becomes a waypoint, /a/b is the leaf
+	// /b is still a leaf
+	// So we have: /a/b, /b = 2 patterns? No, /a is still a potential endpoint
+	// Actually, patterns = leaves, and /a might not be a leaf anymore if it has children
+	// Let's check: after /a/b, node "a" has child "b", so "a" is not a leaf
+	// Patterns = /a/b (1) + /b (1) = 2
+	// Wait, before we had /a as a leaf. Now /a has a child, so it's not a leaf.
+	// So pattern count should still be 2: /a/b and /b
+	assert.Equal(t, 2, trie.PatternCount(), "pattern count after adding child")
+}
+
+// Tests for TTL-based pattern pruning
+
+func TestPathTrie_PruneStale_TTLDisabled(t *testing.T) {
+	// When PatternTTL=0, no pruning should happen
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         0, // disabled
+	})
+	require.NoError(t, err)
+
+	trie.Insert("/api/v1/users")
+	trie.Insert("/api/v2/users")
+	assert.Equal(t, 2, trie.PatternCount())
+
+	// Pruning should do nothing when TTL is disabled
+	pruned := trie.PruneStale(time.Now().Add(time.Hour))
+	assert.Equal(t, 0, pruned, "no patterns should be pruned when TTL is disabled")
+	assert.Equal(t, 2, trie.PatternCount())
+}
+
+func TestPathTrie_PruneStale_FreshPatternsPreserved(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         time.Hour,
+	})
+	require.NoError(t, err)
+
+	trie.Insert("/api/v1/users")
+	trie.Insert("/api/v2/users")
+	assert.Equal(t, 2, trie.PatternCount())
+
+	// Cutoff in the past - patterns are fresh
+	cutoff := time.Now().Add(-time.Hour)
+	pruned := trie.PruneStale(cutoff)
+	assert.Equal(t, 0, pruned, "fresh patterns should not be pruned")
+	assert.Equal(t, 2, trie.PatternCount())
+}
+
+func TestPathTrie_PruneStale_StalePatternsRemoved(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         time.Hour,
+	})
+	require.NoError(t, err)
+
+	trie.Insert("/api/v1/users")
+	trie.Insert("/api/v2/users")
+	assert.Equal(t, 2, trie.PatternCount())
+
+	// Cutoff in the future - all patterns are stale
+	cutoff := time.Now().Add(time.Hour)
+	pruned := trie.PruneStale(cutoff)
+	assert.Equal(t, 2, pruned, "stale patterns should be pruned")
+	assert.Equal(t, 0, trie.PatternCount())
+}
+
+func TestPathTrie_PruneStale_ParentCleanup(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         time.Hour,
+	})
+	require.NoError(t, err)
+
+	trie.Insert("/api/v1/users/profile")
+	trie.Insert("/api/v1/users/settings")
+	initialNodeCount := trie.NodeCount()
+	assert.Equal(t, 2, trie.PatternCount())
+
+	// Prune all (cutoff in future)
+	cutoff := time.Now().Add(time.Hour)
+	pruned := trie.PruneStale(cutoff)
+	assert.Equal(t, 2, pruned)
+	assert.Equal(t, 0, trie.PatternCount())
+
+	// Node count should be reduced (empty parents cleaned up)
+	assert.Less(t, trie.NodeCount(), initialNodeCount, "empty parent nodes should be cleaned up")
+}
+
+func TestPathTrie_PruneStale_PartialPrune(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Insert first pattern
+	trie.Insert("/api/v1/users")
+	time.Sleep(10 * time.Millisecond)
+	midPoint := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	// Insert second pattern later
+	trie.Insert("/api/v2/users")
+	assert.Equal(t, 2, trie.PatternCount())
+
+	// Prune only the first pattern (cutoff between the two inserts)
+	pruned := trie.PruneStale(midPoint)
+	assert.Equal(t, 1, pruned, "only older pattern should be pruned")
+	assert.Equal(t, 1, trie.PatternCount())
+
+	// v2 should still be accessible
+	result := trie.Lookup("/api/v2/users")
+	assert.Equal(t, "/api/v2/users", result)
+}
+
+func TestPathTrie_Stop_TerminatesGoroutine(t *testing.T) {
+	goroutinesBefore := runtime.NumGoroutine()
+
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         time.Hour,
+		PruneInterval:      10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	// Goroutine count should have increased
+	assert.Greater(t, runtime.NumGoroutine(), goroutinesBefore, "pruning goroutine should have started")
+
+	trie.Insert("/api/v1/users")
+
+	// Stop should terminate the goroutine
+	trie.Stop()
+
+	// Goroutine count should be back to original
+	assert.Equal(t, goroutinesBefore, runtime.NumGoroutine(), "pruning goroutine should have stopped")
+
+	// Multiple calls to Stop should be safe
+	trie.Stop()
+}
+
+func TestPathTrie_Stop_NoGoroutine(t *testing.T) {
+	// Stop should be safe to call even when no goroutine was started
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         0, // no pruning
+	})
+	require.NoError(t, err)
+
+	// Should not panic
+	trie.Stop()
+}
+
+func TestPathTrie_BackgroundPruning(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 100,
+		HardMaxCardinality: 200,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         50 * time.Millisecond,
+		PruneInterval:      20 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer trie.Stop()
+
+	trie.Insert("/api/v1/users")
+	assert.Equal(t, 1, trie.PatternCount())
+
+	// Wait for TTL to expire and pruning to occur
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 0, trie.PatternCount(), "pattern should be pruned by background goroutine")
+}
+
+func TestPathTrie_ConcurrentInsertAndPrune(t *testing.T) {
+	trie, err := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 10,
+		HardMaxCardinality: 100,
+		MaxPatterns:        0,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+		PatternTTL:         time.Hour,
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	// Concurrent inserts
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				trie.Insert("/api/v" + strconv.Itoa(id) + "/resource/" + strconv.Itoa(j))
+			}
+		}(i)
+	}
+
+	// Concurrent prunes
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				trie.PruneStale(time.Now().Add(-time.Second))
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Trie should still be functional
+	result := trie.Lookup("/api/v0/resource/0")
+	assert.NotEmpty(t, result)
 }
 
 // Benchmarks
@@ -499,175 +979,4 @@ func BenchmarkPathTrie_InsertWithCollapse(b *testing.B) {
 			trie.Insert(path)
 		}
 	}
-}
-
-// Tests for global pattern limit (MaxPatterns)
-
-func TestPathTrie_MaxPatterns_UnderLimit(t *testing.T) {
-	// Test that patterns under the limit are not affected
-	trie, err := NewPathTrie(&TrieConfig{
-		SoftMaxCardinality: 5,
-		HardMaxCardinality: 100,
-		MaxPatterns:        20,
-		ReplaceWith:        "*",
-		Separator:          "/",
-		MaxDepth:           20,
-	})
-	require.NoError(t, err)
-
-	// Insert paths that create patterns under the limit
-	for i := 0; i < 5; i++ {
-		trie.Insert("/api/v" + strconv.Itoa(i) + "/users")
-	}
-
-	// All should be explicit since under both soft threshold and max patterns
-	for i := 0; i < 5; i++ {
-		result := trie.Lookup("/api/v" + strconv.Itoa(i) + "/users")
-		assert.Contains(t, result, "v"+strconv.Itoa(i), "should remain explicit when under limits")
-	}
-
-	assert.LessOrEqual(t, trie.PatternCount(), 20, "pattern count should be under limit")
-}
-
-func TestPathTrie_MaxPatterns_EnforceLimit(t *testing.T) {
-	// Test that exceeding MaxPatterns triggers hard collapse of deepest nodes
-	trie, err := NewPathTrie(&TrieConfig{
-		SoftMaxCardinality: 3,
-		HardMaxCardinality: 100, // High hard limit so it doesn't interfere
-		MaxPatterns:        10,
-		ReplaceWith:        "*",
-		Separator:          "/",
-		MaxDepth:           20,
-	})
-	require.NoError(t, err)
-
-	// Insert many paths at different depths to create many patterns
-	// These will create paths like /a/b1/c1, /a/b1/c2, etc.
-	for i := 0; i < 4; i++ {
-		for j := 0; j < 4; j++ {
-			trie.Insert("/a/b" + strconv.Itoa(i) + "/c" + strconv.Itoa(j))
-		}
-	}
-
-	// Pattern count should be enforced to stay at or below MaxPatterns
-	assert.LessOrEqual(t, trie.PatternCount(), 10, "pattern count should not exceed MaxPatterns")
-}
-
-func TestPathTrie_MaxPatterns_DeepestCollapsedFirst(t *testing.T) {
-	// Test that deeper soft-collapsed nodes are hard-collapsed before shallower ones
-	trie, err := NewPathTrie(&TrieConfig{
-		SoftMaxCardinality: 2,
-		HardMaxCardinality: 100,
-		MaxPatterns:        5,
-		ReplaceWith:        "*",
-		Separator:          "/",
-		MaxDepth:           20,
-	})
-	require.NoError(t, err)
-
-	// Create a structure with soft-collapsed nodes at different depths
-	// First, create explicit paths at depth 1 (under soft threshold)
-	trie.Insert("/api/v1/resource/item1")
-	trie.Insert("/api/v1/resource/item2")
-	trie.Insert("/api/v2/resource/item1")
-	trie.Insert("/api/v2/resource/item2")
-
-	// These will cause soft collapse at depth 2 (under /api/v1/resource/)
-	trie.Insert("/api/v1/resource/item3")
-	trie.Insert("/api/v1/resource/item4")
-
-	// When pattern limit is exceeded, deeper nodes should collapse first
-	// The node at depth 2 (resource level) should collapse before depth 1
-	patternCount := trie.PatternCount()
-	assert.LessOrEqual(t, patternCount, 5, "pattern count should be enforced")
-}
-
-func TestPathTrie_MaxPatterns_NoLimitWithZero(t *testing.T) {
-	// Test that MaxPatterns=0 means no limit
-	trie, err := NewPathTrie(&TrieConfig{
-		SoftMaxCardinality: 3,
-		HardMaxCardinality: 100,
-		MaxPatterns:        0, // No limit
-		ReplaceWith:        "*",
-		Separator:          "/",
-		MaxDepth:           20,
-	})
-	require.NoError(t, err)
-
-	// Insert many paths
-	for i := 0; i < 20; i++ {
-		trie.Insert("/segment" + strconv.Itoa(i) + "/sub")
-	}
-
-	// With no pattern limit, soft collapse should still happen at threshold 3
-	// but no global enforcement
-	// First 3 are explicit, rest go to wildcard but patterns still grow
-	assert.Greater(t, trie.PatternCount(), 0, "should have some patterns")
-}
-
-func TestPathTrie_MaxPatterns_NoCandidates(t *testing.T) {
-	// Test that if there are no soft-collapsed candidates, we accept over limit
-	trie, err := NewPathTrie(&TrieConfig{
-		SoftMaxCardinality: 100, // Very high so nothing soft collapses
-		HardMaxCardinality: 200,
-		MaxPatterns:        5,
-		ReplaceWith:        "*",
-		Separator:          "/",
-		MaxDepth:           20,
-	})
-	require.NoError(t, err)
-
-	// Insert paths - none will soft collapse since soft threshold is high
-	for i := 0; i < 10; i++ {
-		trie.Insert("/api/v" + strconv.Itoa(i))
-	}
-
-	// Since no nodes are soft-collapsed, there are no candidates to collapse
-	// Pattern count may exceed limit
-	assert.Equal(t, 10, trie.PatternCount(), "should have 10 patterns with no collapse candidates")
-}
-
-func TestPathTrie_MaxPatterns_ValidationNegative(t *testing.T) {
-	// Test that negative MaxPatterns is rejected
-	_, err := NewPathTrie(&TrieConfig{
-		SoftMaxCardinality: 10,
-		HardMaxCardinality: 100,
-		MaxPatterns:        -1,
-		ReplaceWith:        "*",
-		Separator:          "/",
-		MaxDepth:           20,
-	})
-	assert.Error(t, err, "negative MaxPatterns should be rejected")
-	assert.Contains(t, err.Error(), "MaxPatterns")
-}
-
-func TestPathTrie_PatternCount(t *testing.T) {
-	trie, err := NewPathTrie(&TrieConfig{
-		SoftMaxCardinality: 100,
-		HardMaxCardinality: 200,
-		MaxPatterns:        0,
-		ReplaceWith:        "*",
-		Separator:          "/",
-		MaxDepth:           20,
-	})
-	require.NoError(t, err)
-
-	assert.Equal(t, 0, trie.PatternCount(), "empty trie should have 0 patterns")
-
-	trie.Insert("/a")
-	assert.Equal(t, 1, trie.PatternCount(), "one path should create one pattern")
-
-	trie.Insert("/b")
-	assert.Equal(t, 2, trie.PatternCount(), "two paths should create two patterns")
-
-	trie.Insert("/a/b")
-	// /a becomes a waypoint, /a/b is the leaf
-	// /b is still a leaf
-	// So we have: /a/b, /b = 2 patterns? No, /a is still a potential endpoint
-	// Actually, patterns = leaves, and /a might not be a leaf anymore if it has children
-	// Let's check: after /a/b, node "a" has child "b", so "a" is not a leaf
-	// Patterns = /a/b (1) + /b (1) = 2
-	// Wait, before we had /a as a leaf. Now /a has a child, so it's not a leaf.
-	// So pattern count should still be 2: /a/b and /b
-	assert.Equal(t, 2, trie.PatternCount(), "pattern count after adding child")
 }

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -802,6 +802,8 @@ func TestPathTrie_Stop_TerminatesGoroutine(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	trie.Start()
+
 	// Goroutine count should have increased
 	assert.Greater(t, runtime.NumGoroutine(), goroutinesBefore, "pruning goroutine should have started")
 
@@ -846,6 +848,7 @@ func TestPathTrie_BackgroundPruning(t *testing.T) {
 		PruneInterval:      20 * time.Millisecond,
 	})
 	require.NoError(t, err)
+	trie.Start()
 	defer trie.Stop()
 
 	trie.Insert("/api/v1/users")

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -497,6 +497,57 @@ func TestTrieConfig_Validate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "depth soft > hard (using default hard)",
+			config: &TrieConfig{
+				SoftMaxCardinality:     10,
+				HardMaxCardinality:     100,
+				DepthSoftCardinalities: map[int]int{0: 150}, // 150 > default hard 100
+				ReplaceWith:            "*",
+				Separator:              "/",
+				MaxDepth:               20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "depth soft > depth hard",
+			config: &TrieConfig{
+				SoftMaxCardinality:     10,
+				HardMaxCardinality:     100,
+				DepthSoftCardinalities: map[int]int{0: 50},
+				DepthHardCardinalities: map[int]int{0: 20}, // 20 < soft 50
+				ReplaceWith:            "*",
+				Separator:              "/",
+				MaxDepth:               20,
+			},
+			wantErr: true,
+		},
+		{
+			name: "depth soft with no hard limit is valid",
+			config: &TrieConfig{
+				SoftMaxCardinality:     10,
+				HardMaxCardinality:     100,
+				DepthSoftCardinalities: map[int]int{0: 500},
+				DepthHardCardinalities: map[int]int{0: -1}, // no limit
+				ReplaceWith:            "*",
+				Separator:              "/",
+				MaxDepth:               20,
+			},
+			wantErr: false,
+		},
+		{
+			name: "depth soft -1 with any hard is valid",
+			config: &TrieConfig{
+				SoftMaxCardinality:     10,
+				HardMaxCardinality:     100,
+				DepthSoftCardinalities: map[int]int{0: -1}, // no soft limit
+				DepthHardCardinalities: map[int]int{0: 5},
+				ReplaceWith:            "*",
+				Separator:              "/",
+				MaxDepth:               20,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Based on https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/pkg/internal/transform/route/clusterurl/trie.go but with the ability to set maxCardinality for each level.

Looking at a list of 18000 URLs generated by Grafana (after gibberish detection), I ran this with the following results:

`maxCardinality=30` at `depth=0`, and `maxCardinality=10` by default.

```
go run ./cmd/evaluate -max-card 10 -depth0-card=30 -top 100
URLs after collapsing: 17
15137  /*/*/*
 1150  /*/*/*/*/*/*
  964  /*/*/*/*
  257  /*/*/*/*/*/*/*
  218  /*/*/*/*/*
  165  /*/*
   58  /*/*/*/*/*/*/*/*
   30  /*
   12  /*/*/*/*/*/*/*/*/*
   10  /*/*/*/*/*/*/*/*/**
    4  /*/*/*/*/*/*/*/*/overview
    3  /*/*/*/*/*/*/*/*/network
    3  /*/*/*/*/*/*/*/*/memory
    1  /*/*/*/*/*/*/*/*/rate
    1  /
    1  /*/*/*/*/*/*/*/*/storage
    1  /*/*/*//*/*/*/*/*
```

`maxCardinality=-1 (NEVER COLLAPSE)` at `depth=0`, and `maxCardinality=10` by default.

```
go run ./cmd/evaluate -max-card 10 -depth0-card=-1 -top 10
URLs after collapsing: 153
14118  /d/*/*
 1150  /a/*/*/*/*/*
  810  /d-solo/*/*
  743  /dashboards/f/*/*
  185  /alerting/*/*/*/groups/*/view
  145  /a/*/*/*/*
  109  /alerting/*/*/*
   91  /a/*/*
   90  /a/*/*/*
   68  /a/*/*/*/*/*/*
```

----

### Final Solution

The issue here is that if we cross the `max-card`, especially at one of the initial depths, we can easily cause a cascade and end up with `/*/*/*/*`. And the immediate change after such a cascade is too big. 

So to iterate on this, I added a `softMaxCard` and `hardMaxCard`. We will store the segments as-is until `softMaxCard`, and any segments _after_ `softMaxCard` we return `*`, but the original segments aren't collapsed yet.

So if we had `softMaxCard` is `2`, and we see the URLs:

```
/books/harry-potter
/books/the-expanse
/books/earthsea-trilogy
```

We will collapse them into:

```
/books/harry-potter
/books/the-expanse
/books/*    <-- also any future books
```

And only when unique segments seen hits `hardMaxCard`, we collapse the whole thing into `/books/*`. So we can have a high cardinality threshold and only collapse really high cardinality segments without blowing up the overall _output cardinality._

However, this adds additional statefulness to the equation, where we need to store the segments we see between `softMax` and `hardMax` in a map.

Overall, the output of this is quite good (see: `/a/grafana-app-observabilit-app/` prefix):

```
  148  /alerting/grafana/namespaces/*/groups/*/view
   88  /a/grafana-app-observability-app/services/service/*
   55  /d/*
   53  /a/*/*/*
   52  /a/*/*
   49  /alerting/*/*/view
   46  /dashboards/f/*
   44  /dashboards/f/*/*/alerting
   35  /a/*/*/*/*
   32  /a/grafana-app-observability-app/services/service/*/traces
   27  /alerting/*/*/find
   23  /a/grafana-app-observability-app/services/service/*/logs
   19  /a/*
   18  /d-report/*
   16  /a/grafana-app-observability-app/services/service/*/operations/*
   15  /a/grafana-app-observability-app/services/service/*/operations/*/traces
...
    9  /dashboards/f/*/*/library-panels
    6  /alerting/grafana/*/view
    6  /connections/add-new-connection/*
    6  /alerting/*/edit
    6  /connections/datasources/*
    5  /a/grafana-app-observability-app/services/service/*/java
....
    4  /a/grafana-app-observability-app/services/service/*/dotnet
....
    3  /a/grafana-app-observability-app/services/service/*/profiles
```

However, this can still cause a cardinality blowup, so I added a `maxPatterns`, after which we immediately collapse after `softMaxCard`. 

And finally, I also added a TTL based pruning so we can prune stale patterns.