### PR TITLE
trie: Use RLock() by default, and upgrade only when changes exist

### DIFF
--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -152,19 +152,23 @@ func (t *PathTrie) Insert(path string) string {
 		return path
 	}
 
-	result := t.insertSegments(segments)
+	result, changed := t.insertSegments(segments)
 
-	// Update pattern count and enforce limit
-	t.updatePatternCount()
-	t.enforcePatternLimit()
+	// Only update pattern count and enforce limit if the trie was modified
+	if changed {
+		t.updatePatternCount()
+		t.enforcePatternLimit()
+	}
 
 	return t.cfg.Separator + strings.Join(result, t.cfg.Separator)
 }
 
-// insertSegments inserts segments into the trie and returns the resulting path.
-func (t *PathTrie) insertSegments(segments []string) []string {
+// insertSegments inserts segments into the trie and returns the resulting path
+// and whether the trie was structurally modified (new nodes created or nodes collapsed).
+func (t *PathTrie) insertSegments(segments []string) ([]string, bool) {
 	current := t.root
 	result := make([]string, 0, len(segments))
+	changed := false
 
 	// We start at depth=0, with current=root (depth=-1).
 	// This means current.depth is always `depth-1`.
@@ -198,6 +202,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 
 			// Check if this is a new unique segment we haven't seen before
 			if _, seen := current.wildcardedSegments[segment]; !seen {
+				changed = true
 				current.wildcardedSegments[segment] = struct{}{}
 				current.uniqueChildrenSeen++
 
@@ -226,7 +231,8 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 			continue
 		}
 
-		// New segment - check soft threshold
+		// New segment - trie is being modified
+		changed = true
 		current.uniqueChildrenSeen++
 		softMax := t.getSoftMaxCardinality(depth)
 
@@ -271,7 +277,7 @@ func (t *PathTrie) insertSegments(segments []string) []string {
 		current.lastSeen = time.Now()
 	}
 
-	return result
+	return result, changed
 }
 
 // getOrCreateWildcardChild returns the wildcard child of a node, creating it if needed.

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -38,9 +39,9 @@ type pathNode struct {
 	// depth is the depth of this node in the trie (root children = 0)
 	depth int
 
-	// lastSeen is when this node was last accessed via Insert.
-	// Used for TTL-based pruning.
-	lastSeen time.Time
+	// lastSeen stores time.Now().UnixNano() when this node was last accessed via Insert.
+	// Used for TTL-based pruning. Zero means "never seen".
+	lastSeen atomic.Int64
 }
 
 // PathTrie is a thread-safe trie for clustering URL paths.
@@ -144,15 +145,25 @@ func (t *PathTrie) parsePath(path string) []string {
 // Additionally, if MaxPatterns is exceeded, deepest soft-collapsed nodes are hard-collapsed.
 // Thread-safe.
 func (t *PathTrie) Insert(path string) string {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	segments := t.parsePath(path)
 	if len(segments) == 0 {
 		return path
 	}
 
-	result, changed := t.insertSegments(segments)
+	// Fast path: read-only traversal under RLock
+	t.mu.RLock()
+	result, _ := t.insertSegments(segments, true)
+	t.mu.RUnlock()
+
+	if result != nil {
+		return t.cfg.Separator + strings.Join(result, t.cfg.Separator)
+	}
+
+	// Slow path: full write lock
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	result, changed := t.insertSegments(segments, false)
 
 	// Only update pattern count and enforce limit if the trie was modified
 	if changed {
@@ -165,7 +176,8 @@ func (t *PathTrie) Insert(path string) string {
 
 // insertSegments inserts segments into the trie and returns the resulting path
 // and whether the trie was structurally modified (new nodes created or nodes collapsed).
-func (t *PathTrie) insertSegments(segments []string) ([]string, bool) {
+// When readOnly is true, the method returns (nil, false) if any write would be needed.
+func (t *PathTrie) insertSegments(segments []string, readOnly bool) ([]string, bool) {
 	current := t.root
 	result := make([]string, 0, len(segments))
 	changed := false
@@ -186,8 +198,15 @@ func (t *PathTrie) insertSegments(segments []string) ([]string, bool) {
 
 		// Case 1: Node is hard collapsed - everything goes to wildcard
 		if current.hardCollapsed {
+			wc := current.children[t.cfg.ReplaceWith]
+			if wc == nil {
+				if readOnly {
+					return nil, false
+				}
+				wc = t.getOrCreateWildcardChild(current)
+			}
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcardChild(current)
+			current = wc
 			continue
 		}
 
@@ -202,6 +221,9 @@ func (t *PathTrie) insertSegments(segments []string) ([]string, bool) {
 
 			// Check if this is a new unique segment we haven't seen before
 			if _, seen := current.wildcardedSegments[segment]; !seen {
+				if readOnly {
+					return nil, false
+				}
 				changed = true
 				current.wildcardedSegments[segment] = struct{}{}
 				current.uniqueChildrenSeen++
@@ -217,8 +239,15 @@ func (t *PathTrie) insertSegments(segments []string) ([]string, bool) {
 			}
 
 			// Use wildcard
+			wc := current.children[t.cfg.ReplaceWith]
+			if wc == nil {
+				if readOnly {
+					return nil, false
+				}
+				wc = t.getOrCreateWildcardChild(current)
+			}
 			result = append(result, t.cfg.ReplaceWith)
-			current = t.getOrCreateWildcardChild(current)
+			current = wc
 			continue
 		}
 
@@ -229,6 +258,10 @@ func (t *PathTrie) insertSegments(segments []string) ([]string, bool) {
 			result = append(result, segment)
 			current = child
 			continue
+		}
+
+		if readOnly {
+			return nil, false
 		}
 
 		// New segment - trie is being modified
@@ -274,7 +307,7 @@ func (t *PathTrie) insertSegments(segments []string) ([]string, bool) {
 
 	// Update lastSeen on the final node for TTL tracking
 	if current != t.root {
-		current.lastSeen = time.Now()
+		current.lastSeen.Store(time.Now().UnixNano())
 	}
 
 	return result, changed
@@ -562,12 +595,13 @@ func (t *PathTrie) pruneNode(node *pathNode, cutoff time.Time) int {
 		// 1. It's a leaf (no children) AND
 		// 2. Either it has a stale lastSeen, OR it has no lastSeen (empty intermediate node)
 		if len(child.children) == 0 {
+			lastSeen := child.lastSeen.Load()
 			// If lastSeen is zero, this is an intermediate node that became empty after pruning
 			// If lastSeen is before cutoff, this is a stale leaf
-			if child.lastSeen.IsZero() || child.lastSeen.Before(cutoff) {
+			if lastSeen == 0 || lastSeen < cutoff.UnixNano() {
 				toDelete = append(toDelete, segment)
 				// Only count as pruned if it was a real leaf (had lastSeen set)
-				if !child.lastSeen.IsZero() {
+				if lastSeen != 0 {
 					pruned++
 				}
 			}

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -1014,6 +1014,34 @@ func BenchmarkPathTrie_Lookup(b *testing.B) {
 	}
 }
 
+func BenchmarkPathTrie_InsertExisting(b *testing.B) {
+	trie, _ := NewPathTrie(&TrieConfig{
+		SoftMaxCardinality: 10,
+		HardMaxCardinality: 100,
+		ReplaceWith:        "*",
+		Separator:          "/",
+		MaxDepth:           20,
+	})
+
+	paths := []string{
+		"/users/profile/details",
+		"/api/v1/orders",
+		"/products/categories/electronics",
+		"/api/v2/settings",
+		"/health/ready",
+	}
+	for _, path := range paths {
+		trie.Insert(path)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, path := range paths {
+			trie.Insert(path)
+		}
+	}
+}
+
 func BenchmarkPathTrie_InsertWithCollapse(b *testing.B) {
 	paths := make([]string, 1000)
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
## Use RLock() by default, and upgrade only when changes exist

The idea is that most writes will hit existing paths, and having a write
lock severly limits throughput.

With this commit, we now take an `RLock()` by default and only upgrade
if there are changes to be made.
